### PR TITLE
Verusfmt CLI improvements + Idempotence Test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* When running verusfmt on multiple files, continue attempting files even if one in the middle fails
+
 # v0.2.5
 
 * Fix `FnSpec` parsing

--- a/tests/rustfmt-does-not-touch-verus.rs
+++ b/tests/rustfmt-does-not-touch-verus.rs
@@ -12,7 +12,7 @@ fn mod_macro_item_idempotent() {
     }
   }
 "#;
-    let formatted1 = verusfmt::rustfmt(&verusfmt::parse_and_format(file).unwrap()).unwrap();
-    let formatted2 = verusfmt::rustfmt(&verusfmt::parse_and_format(&formatted1).unwrap()).unwrap();
+    let formatted1 = verusfmt::run(file, Default::default()).unwrap();
+    let formatted2 = verusfmt::run(&formatted1, Default::default()).unwrap();
     assert_eq!(formatted1, formatted2);
 }

--- a/tests/snapshot-examples.rs
+++ b/tests/snapshot-examples.rs
@@ -5,7 +5,7 @@
 //! modified by any change.
 
 fn check_snapshot(original: &str) {
-    let formatted = verusfmt::rustfmt(&verusfmt::parse_and_format(&original).unwrap()).unwrap();
+    let formatted = verusfmt::run(original, Default::default()).unwrap();
     if original != formatted {
         let diff = similar::udiff::unified_diff(
             similar::Algorithm::Patience,

--- a/util/idempotency-interesting.sh
+++ b/util/idempotency-interesting.sh
@@ -1,0 +1,25 @@
+#! /bin/bash
+
+################################################################################
+#
+# This script is used to test the idempotency of the formatter.
+#
+# Usage:
+#   creduce ./util/idempotency-interesting.sh foo.rs
+#
+################################################################################
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+if [ $# -eq 1 ]; then
+	FILE=$1
+else
+	echo "[!] No file specified, using foo.rs" 1>&2
+	FILE="foo.rs"
+fi
+
+if "$DIR/../target/release/verusfmt" "$FILE" -Z idempotency-test; then
+	exit 0
+else
+	exit 1
+fi


### PR DESCRIPTION
This PR updates a few things for the CLI:

* When running verusfmt on multiple files, continue attempting files even if one in the middle fails
* Exposes a library function that does the verusfmt+rustfmt interface, approximating the default CLI behavior
* Adds a new (unstable) option that makes it easier to test for idempotency

The idempotence test also comes with a minimizer script (usable with creduce), and this has already helped identify and minimize one such idempotency issue: #36.