### PR TITLE
Apply `cargo clippy` fixes, and enable clippy on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,6 @@ jobs:
         run: rustup toolchain install stable --profile minimal --no-self-update
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --check --verbose
+      - run: cargo clippy --verbose
       - run: cargo build --verbose
       - run: cargo test --verbose

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ fn format_file(file: &PathBuf, args: &Args) -> miette::Result<()> {
     if args.check {
         if unparsed_file == formatted_output {
             info!("✨Perfectly formatted✨");
-            return Ok(());
+            Ok(())
         } else {
             info!("Found some differences in {}", file.display());
             error!("Input found not to be well formatted");
@@ -65,7 +65,7 @@ fn format_file(file: &PathBuf, args: &Args) -> miette::Result<()> {
                 )),
             );
             println!("{diff}");
-            return Err(miette!("invalid formatting"));
+            Err(miette!("invalid formatting"))
         }
     } else if matches!(
         args.unstable_command,
@@ -104,7 +104,7 @@ fn format_file(file: &PathBuf, args: &Args) -> miette::Result<()> {
 
 fn main() -> miette::Result<()> {
     let args = Args::parse();
-    if args.files.len() == 0 {
+    if args.files.is_empty() {
         return Err(miette!("No files specified"));
     }
 
@@ -122,7 +122,7 @@ fn main() -> miette::Result<()> {
 
     let mut errors = vec![];
     for file in &args.files {
-        match format_file(&file, &args) {
+        match format_file(file, &args) {
             Ok(()) => {}
             Err(e) => {
                 errors.push(e);

--- a/src/rustfmt.rs
+++ b/src/rustfmt.rs
@@ -134,7 +134,7 @@ fn run_rustfmt(s: &str) -> Option<String> {
 
     let output = proc.wait_with_output().ok()?;
     if output.status.success() {
-        Some(String::from_utf8(output.stdout).unwrap().into())
+        Some(String::from_utf8(output.stdout).unwrap())
     } else {
         eprintln!(
             "\nrustfmt failed! {}\n\tConsider running with --verus-only\n",

--- a/tests/rustfmt-matching.rs
+++ b/tests/rustfmt-matching.rs
@@ -15,7 +15,7 @@ fn compare(file: &str) {
     let diff = similar::udiff::unified_diff(
         similar::Algorithm::Patience,
         &rust_fmt,
-        &verus_inner,
+        verus_inner,
         3,
         Some(("rust", "verus")),
     );

--- a/tests/snapshot-examples.rs
+++ b/tests/snapshot-examples.rs
@@ -9,7 +9,7 @@ fn check_snapshot(original: &str) {
     if original != formatted {
         let diff = similar::udiff::unified_diff(
             similar::Algorithm::Patience,
-            &original,
+            original,
             &formatted,
             3,
             Some(("original", "formatted")),


### PR DESCRIPTION
This should help us maintain a slightly more idiomatic style. 

Clippy warnings _are_ ignorable via a targeted `#[allow(clippy::...)]`, but I don't see any place in our codebase where clippy is suggesting a bad change, so keeping it enabled should lead to maintenance of nicer code overall.