### PR TITLE
suggest `cargo install --locked cargo-insta`

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ test's correct answer is maintained via the [Insta testing framework](https://in
 
 Insta recommends installing the `cargo-insta` tool for an improved review experience:
 ```
-cargo install cargo-insta
+cargo install --locked cargo-insta
 ```
 
 You can run the tests normally with `cargo test`, but it's often more convenient


### PR DESCRIPTION
On my first attempt at following the testing instructions I got:

```
error: failed to compile `cargo-insta v1.37.0`, intermediate artifacts can be found at `/var/folders/rv/r1tp_rss7sxg6dlqdqyk6tnh0000gq/T/cargo-install28wwCs`

Caused by:
  package `cargo-platform v0.1.8` cannot be built because it requires rustc 1.73 or newer, while the currently active rustc version is 1.70.0
  Try re-running cargo install with `--locked`
```