### PR TITLE
Improve `rustfmt.toml` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+* Improve handling of `rustfmt.toml` for non-`verus!` code
+  - Rather than picking up `rustfmt.toml` based on working directory, it is now picked up based on the file being formatted. This now matches the search that `rustfmt` itself does.
+
 # v0.2.10
 
 * Add support for `broadcast proof`, `broadcast group`, and `broadcast use` (see [verus#1022](https://github.com/verus-lang/verus/pull/1022))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "block-buffer"
@@ -234,24 +234,19 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
+name = "fastrand"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
-]
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "fs-err"
@@ -340,9 +335,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "linked-hash-map"
@@ -352,9 +347,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.3"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "log"
@@ -562,15 +557,15 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -654,6 +649,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -840,6 +847,7 @@ dependencies = [
  "pretty",
  "regex",
  "similar",
+ "tempfile",
  "thiserror",
  "tracing",
  "tracing-subscriber",
@@ -886,6 +894,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.4",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +933,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,6 +958,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -940,6 +978,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,6 +994,12 @@ name = "windows_i686_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -964,6 +1014,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,6 +1030,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -988,6 +1050,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,6 +1066,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ pest_derive = "2.0"
 pretty = "0.12.1"
 regex = "1.9.6"
 similar = "2.2.1"
+tempfile = "3.10.1"
 thiserror = "1.0.52"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17" }

--- a/examples/verus-snapshot/get_latest.sh
+++ b/examples/verus-snapshot/get_latest.sh
@@ -12,7 +12,7 @@ wget --quiet -O verus.zip https://github.com/verus-lang/verus/archive/refs/heads
 echo "[INFO] Unzipping Verus"
 unzip -q verus.zip
 
-MOVE_PATHS="source/rust_verify/example/syntax.rs source/vstd"
+MOVE_PATHS="source/rustfmt.toml source/rust_verify/example/syntax.rs source/vstd"
 
 echo "[INFO] Moving files"
 for path in $MOVE_PATHS; do

--- a/examples/verus-snapshot/source/rustfmt.toml
+++ b/examples/verus-snapshot/source/rustfmt.toml
@@ -1,0 +1,7 @@
+# Copied from Rust compiler's rustfmt.toml settings
+
+# Run rustfmt with this config (it should be picked up automatically).
+# unstable_features=true # provided by vargo
+# version=Two # provided by vargo
+use_small_heuristics = "Max"
+merge_derives = false

--- a/examples/verus-snapshot/source/vstd/source/vstd/atomic.rs
+++ b/examples/verus-snapshot/source/vstd/source/vstd/atomic.rs
@@ -471,13 +471,7 @@ macro_rules! atomic_bool_methods {
     };
 }
 
-make_bool_atomic!(
-    PAtomicBool,
-    PermissionBool,
-    PermissionDataBool,
-    AtomicBool,
-    bool
-);
+make_bool_atomic!(PAtomicBool, PermissionBool, PermissionDataBool, AtomicBool, bool);
 
 make_unsigned_integer_atomic!(
     PAtomicU8,

--- a/examples/verus-snapshot/source/vstd/source/vstd/atomic_ghost.rs
+++ b/examples/verus-snapshot/source/vstd/source/vstd/atomic_ghost.rs
@@ -114,33 +114,15 @@ declare_atomic_type!(AtomicU64, PAtomicU64, PermissionU64, u64, AtomicPredU64);
 declare_atomic_type!(AtomicU32, PAtomicU32, PermissionU32, u32, AtomicPredU32);
 declare_atomic_type!(AtomicU16, PAtomicU16, PermissionU16, u16, AtomicPredU16);
 declare_atomic_type!(AtomicU8, PAtomicU8, PermissionU8, u8, AtomicPredU8);
-declare_atomic_type!(
-    AtomicUsize,
-    PAtomicUsize,
-    PermissionUsize,
-    usize,
-    AtomicPredUsize
-);
+declare_atomic_type!(AtomicUsize, PAtomicUsize, PermissionUsize, usize, AtomicPredUsize);
 
 declare_atomic_type!(AtomicI64, PAtomicI64, PermissionI64, i64, AtomicPredI64);
 declare_atomic_type!(AtomicI32, PAtomicI32, PermissionI32, i32, AtomicPredI32);
 declare_atomic_type!(AtomicI16, PAtomicI16, PermissionI16, i16, AtomicPredI16);
 declare_atomic_type!(AtomicI8, PAtomicI8, PermissionI8, i8, AtomicPredI8);
-declare_atomic_type!(
-    AtomicIsize,
-    PAtomicIsize,
-    PermissionIsize,
-    isize,
-    AtomicPredIsize
-);
+declare_atomic_type!(AtomicIsize, PAtomicIsize, PermissionIsize, isize, AtomicPredIsize);
 
-declare_atomic_type!(
-    AtomicBool,
-    PAtomicBool,
-    PermissionBool,
-    bool,
-    AtomicPredBool
-);
+declare_atomic_type!(AtomicBool, PAtomicBool, PermissionBool, bool, AtomicPredBool);
 
 /// Performs a given atomic operation on a given atomic
 /// while providing access to its ghost state.

--- a/examples/verus-snapshot/source/vstd/source/vstd/std_specs/num.rs
+++ b/examples/verus-snapshot/source/vstd/source/vstd/std_specs/num.rs
@@ -165,20 +165,8 @@ num_specs!(u8, i8, u8_specs, i8_specs, 0x100);
 num_specs!(u16, i16, u16_specs, i16_specs, 0x1_0000);
 num_specs!(u32, i32, u32_specs, i32_specs, 0x1_0000_0000);
 num_specs!(u64, i64, u64_specs, i64_specs, 0x1_0000_0000_0000_0000);
-num_specs!(
-    u128,
-    i128,
-    u128_specs,
-    i128_specs,
-    0x1_0000_0000_0000_0000_0000_0000_0000_0000
-);
-num_specs!(
-    usize,
-    isize,
-    usize_specs,
-    isize_specs,
-    (usize::MAX - usize::MIN + 1)
-);
+num_specs!(u128, i128, u128_specs, i128_specs, 0x1_0000_0000_0000_0000_0000_0000_0000_0000);
+num_specs!(usize, isize, usize_specs, isize_specs, (usize::MAX - usize::MIN + 1));
 
 verus! {
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1514,7 +1514,7 @@ impl miette::Diagnostic for ParseAndFormatError {
     }
 }
 
-pub fn parse_and_format(s: &str) -> miette::Result<String> {
+fn parse_and_format(s: &str) -> miette::Result<String> {
     let ctx = Context {
         inline_comment_lines: find_inline_comment_lines(s),
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 
 mod rustfmt;
 
-pub use crate::rustfmt::rustfmt;
+pub use crate::rustfmt::{rustfmt, RustFmtConfig};
 
 use itertools::Itertools;
 use pest::{iterators::Pair, iterators::Pairs, Parser};
@@ -1596,6 +1596,8 @@ pub struct RunOptions {
     pub file_name: Option<String>,
     /// Whether to run rustfmt on non-verus parts of code.
     pub run_rustfmt: bool,
+    /// Whether to perform extra configuration for the rustfmt run. Ignored if `run_rustfmt` is false.
+    pub rustfmt_config: RustFmtConfig,
 }
 
 impl Default for RunOptions {
@@ -1603,6 +1605,7 @@ impl Default for RunOptions {
         Self {
             file_name: None,
             run_rustfmt: true,
+            rustfmt_config: Default::default(),
         }
     }
 }
@@ -1622,7 +1625,9 @@ pub fn run(s: &str, opts: RunOptions) -> miette::Result<String> {
     let formatted_output = if !opts.run_rustfmt {
         verus_fmted
     } else {
-        rustfmt(&verus_fmted).ok_or(miette::miette!("rustfmt failed"))?
+        opts.rustfmt_config
+            .run(&verus_fmted)
+            .ok_or(miette::miette!("rustfmt failed"))?
     };
 
     Ok(formatted_output)

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ fn format_file(file: &PathBuf, args: &Args) -> miette::Result<()> {
         verusfmt::RunOptions {
             file_name: Some(file.to_string_lossy().into()),
             run_rustfmt: !args.verus_only,
+            rustfmt_config: Default::default(),
         },
     )?;
 
@@ -76,6 +77,7 @@ fn format_file(file: &PathBuf, args: &Args) -> miette::Result<()> {
             verusfmt::RunOptions {
                 file_name: Some(file.to_string_lossy().into()),
                 run_rustfmt: !args.verus_only,
+                rustfmt_config: Default::default(),
             },
         )?;
         if formatted_output == reformatted {

--- a/src/rustfmt.rs
+++ b/src/rustfmt.rs
@@ -23,10 +23,11 @@ pub fn rustfmt(s: &str) -> Option<String> {
 }
 
 /// Options to pass to [`rustfmt_with_config`]
+#[derive(Clone)]
 pub struct RustFmtConfig {
     /// If set, explicitly provides the specified `rustfmt.toml` configuration to rustfmt;
     /// otherwise, uses the default behavior (i.e., picking up `rustfmt.toml` if it exists from
-    /// working directory or ancestors)
+    /// the file's directory or ancestors)
     pub rustfmt_toml: Option<String>,
 }
 

--- a/src/rustfmt.rs
+++ b/src/rustfmt.rs
@@ -15,8 +15,35 @@ fn is_multiline_comment(pair: &Pair<Rule>) -> bool {
     matches!(&pair.as_span().as_str()[..2], "/*")
 }
 
-/// Run rustfmt, only on code outside the `verus!` macro
+/// Run rustfmt, only on code outside the `verus!` macro.
+///
+/// Convenience wrapper around [`RustFmtConfig`]. Equivalent to `RustFmtConfig::default().run(s)`.
 pub fn rustfmt(s: &str) -> Option<String> {
+    RustFmtConfig::default().run(s)
+}
+
+/// Options to pass to [`rustfmt_with_config`]
+pub struct RustFmtConfig {
+    /// If set, explicitly provides the specified `rustfmt.toml` configuration to rustfmt;
+    /// otherwise, uses the default behavior (i.e., picking up `rustfmt.toml` if it exists from
+    /// working directory or ancestors)
+    pub rustfmt_toml: Option<String>,
+}
+
+impl Default for RustFmtConfig {
+    fn default() -> Self {
+        Self { rustfmt_toml: None }
+    }
+}
+
+impl RustFmtConfig {
+    pub fn run(&self, s: &str) -> Option<String> {
+        rustfmt_with_config(s, self)
+    }
+}
+
+/// Run rustfmt, only on code outside the `verus!` macro.
+fn rustfmt_with_config(s: &str, config: &RustFmtConfig) -> Option<String> {
     let parsed_file = MinimalVerusParser::parse(Rule::file, s)
         .expect("Minimal parsing should never fail. If it did, please report this as an error.")
         .next()
@@ -51,7 +78,7 @@ pub fn rustfmt(s: &str) -> Option<String> {
         }
     }
 
-    let formatted = run_rustfmt(&collapsed_input)?;
+    let formatted = run_rustfmt(&collapsed_input, config)?;
 
     let parsed_file = MinimalVerusParser::parse(Rule::file, &formatted)
         .expect("Minimal parsing should never fail. If it did, please report this as an error.")
@@ -116,10 +143,27 @@ pub fn rustfmt(s: &str) -> Option<String> {
     Some(final_output)
 }
 
-fn run_rustfmt(s: &str) -> Option<String> {
-    let mut proc = Command::new("rustfmt")
-        .arg("--emit=stdout")
-        .arg("--edition=2021")
+fn run_rustfmt(s: &str, config: &RustFmtConfig) -> Option<String> {
+    let mut rustfmt = Command::new("rustfmt");
+
+    // Set up standard arguments we always pass
+    rustfmt.arg("--emit=stdout").arg("--edition=2021");
+
+    // If we need to, explicitly set up the rustfmt.toml file
+    let tempdir = config.rustfmt_toml.as_ref().map(|toml| {
+        let tempdir = tempfile::Builder::new()
+            .prefix("verusfmt")
+            .tempdir()
+            .unwrap();
+        std::fs::File::create_new(tempdir.path().join("rustfmt.toml"))
+            .unwrap()
+            .write_all(toml.as_bytes())
+            .unwrap();
+        rustfmt.arg("--config-path").arg(tempdir.path());
+        tempdir
+    });
+
+    let mut proc = rustfmt
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -133,6 +177,7 @@ fn run_rustfmt(s: &str) -> Option<String> {
         .unwrap();
 
     let output = proc.wait_with_output().ok()?;
+    drop(tempdir);
     if output.status.success() {
         Some(String::from_utf8(output.stdout).unwrap())
     } else {

--- a/tests/rustfmt-matching.rs
+++ b/tests/rustfmt-matching.rs
@@ -10,6 +10,7 @@ fn compare(file: &str) {
         verusfmt::RunOptions {
             file_name: None,
             run_rustfmt: false,
+            rustfmt_config: Default::default(),
         },
     )
     .unwrap();

--- a/tests/rustfmt-matching.rs
+++ b/tests/rustfmt-matching.rs
@@ -1,11 +1,18 @@
-use verusfmt::{parse_and_format, rustfmt, VERUS_PREFIX, VERUS_SUFFIX};
+use verusfmt::{rustfmt, VERUS_PREFIX, VERUS_SUFFIX};
 
 /// Tests to check that when formatting standard Rust syntax,
 /// we match rustfmt
 
 fn compare(file: &str) {
     let verus_file = format!("{}{}{}", VERUS_PREFIX, file, VERUS_SUFFIX);
-    let verus_fmt = parse_and_format(&verus_file).unwrap();
+    let verus_fmt = verusfmt::run(
+        &verus_file,
+        verusfmt::RunOptions {
+            file_name: None,
+            run_rustfmt: false,
+        },
+    )
+    .unwrap();
     let start = VERUS_PREFIX.len();
     let end = verus_fmt.len() - VERUS_SUFFIX.len();
     let verus_inner = &verus_fmt[start..end];

--- a/tests/snapshot-examples.rs
+++ b/tests/snapshot-examples.rs
@@ -5,7 +5,11 @@
 //! modified by any change.
 
 fn check_snapshot(original: &str) {
-    let formatted = verusfmt::run(original, Default::default()).unwrap();
+    check_snapshot_with_config(original, Default::default())
+}
+
+fn check_snapshot_with_config(original: &str, config: verusfmt::RunOptions) {
+    let formatted = verusfmt::run(original, config).unwrap();
     if original != formatted {
         let diff = similar::udiff::unified_diff(
             similar::Algorithm::Patience,
@@ -52,9 +56,20 @@ fn pagetable_rs_unchanged() {
 
 #[test]
 fn verus_snapshot_unchanged() {
+    let rustfmt_toml =
+        std::fs::read_to_string("./examples/verus-snapshot/source/rustfmt.toml").unwrap();
     for path in glob::glob("./examples/verus-snapshot/**/*.rs").unwrap() {
         let path = path.unwrap();
         println!("Checking snapshot for {:?}", path);
-        check_snapshot(&std::fs::read_to_string(path).unwrap());
+        check_snapshot_with_config(
+            &std::fs::read_to_string(path).unwrap(),
+            verusfmt::RunOptions {
+                file_name: None,
+                run_rustfmt: true,
+                rustfmt_config: verusfmt::RustFmtConfig {
+                    rustfmt_toml: Some(rustfmt_toml.clone()),
+                },
+            },
+        );
     }
 }

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -11,6 +11,7 @@ fn parse_and_format(s: &str) -> miette::Result<String> {
         verusfmt::RunOptions {
             file_name: None,
             run_rustfmt: true,
+            rustfmt_config: Default::default(),
         },
     )
 }

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -1,10 +1,19 @@
 use insta::assert_snapshot;
-use verusfmt::parse_and_format;
 
 /// Tests of Verus-specific formatting
 
 // We use insta tests (http://insta.rs) to manage the correct answers.
 // See README.md for details on how to run and update these tests.
+
+fn parse_and_format(s: &str) -> miette::Result<String> {
+    verusfmt::run(
+        s,
+        verusfmt::RunOptions {
+            file_name: None,
+            run_rustfmt: true,
+        },
+    )
+}
 
 #[test]
 fn verus_functions() {


### PR DESCRIPTION
This PR does a few things related to `rustfmt.toml`, categorized into stuff that is user-facing, and library API changes.

This should help unblock one major part of https://github.com/verus-lang/verusfmt/pull/46

### User-Facing Changes

* Improve handling of `rustfmt.toml` for non-`verus!` code
  - Rather than picking up `rustfmt.toml` based on working directory, it is now picked up based on the file being formatted. This now matches the search that `rustfmt` itself does.

### Public verusfmt-as-library API

These changes should _basically_ impact nobody, unless they are depending on verusfmt _as a library_ (unlikely, but _technically_ possible; my guess is that only our test code is the user of verusfmt as a library, with everyone else using it as an executable). Nonetheless, listing them here since they are technically changing the library API.

* Remove `parse_and_format` from the public library API
  - The intended usage is now the more extensible `verusfmt::run`
* Add support for passing in an explicit `rustfmt.toml` via the public library API

---

Note: auto-merge for this PR on accepted-review is enabled.
