### PR TITLE
Handle trailing newlines for `broadcast use`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Support attributes on `broadcast group` items
+* Improve styling of `broadcast use`s, ensuring trailing newline
 
 # v0.2.11
 

--- a/examples/verus-snapshot/source/vstd/source/vstd/seq_lib.rs
+++ b/examples/verus-snapshot/source/vstd/source/vstd/seq_lib.rs
@@ -971,6 +971,7 @@ impl<A> Seq<Seq<A>> {
             self.len() == 1 ==> self.flatten() == self.first(),
     {
         broadcast use Seq::add_empty_right;
+
         if self.len() == 1 {
             assert(self.flatten() =~= self.first().add(self.drop_first().flatten()));
         }
@@ -1022,6 +1023,7 @@ impl<A> Seq<Seq<A>> {
         decreases self.len(),
     {
         broadcast use Seq::add_empty_right, Seq::push_distributes_over_add;
+
         if self.len() != 0 {
             self.drop_last().lemma_flatten_and_flatten_alt_are_equivalent();
             seq![self.last()].lemma_flatten_one_element();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,8 +394,16 @@ fn items_to_doc<'a>(
             }
             prev_is_use = is_use;
 
+            let is_broadcast_uses = matches!(
+                item.clone().into_inner().next().unwrap().as_rule(),
+                Rule::broadcast_uses
+            );
             res = res.append(to_doc(ctx, item, arena));
-            res = res.append(arena.line());
+            if !is_broadcast_uses {
+                // Add the newline, but don't add extra newlines between `broadcast use`s since
+                // those already add newlines
+                res = res.append(arena.line());
+            }
             // Add extra space between items, except for use declarations
             if i < len - 1 && !is_use {
                 res = res.append(arena.line());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -991,6 +991,14 @@ fn to_doc<'a>(
         Rule::attr_inner => map_to_doc(ctx, arena, pair),
         Rule::meta => unsupported(pair),
         Rule::broadcast_use => map_to_doc(ctx, arena, pair),
+        Rule::broadcast_uses => arena.concat(pair.into_inner().map(|p| {
+            if matches!(p.as_rule(), Rule::broadcast_use) {
+                to_doc(ctx, p, arena).append(arena.hardline())
+            } else {
+                // Handle the comments
+                to_doc(ctx, p, arena)
+            }
+        })),
         Rule::broadcast_group => map_to_doc(ctx, arena, pair),
 
         //****************************//

--- a/src/verus.pest
+++ b/src/verus.pest
@@ -590,7 +590,7 @@ item_no_macro_call = _{
   | union
   | use
   | broadcast_group
-  | broadcast_use
+  | broadcast_uses
 }
 
 verusfmt_skipped_item = {
@@ -901,6 +901,10 @@ meta = {
 
 broadcast_use_list = {
     (path ~ ("," ~ path)* ~ ","?)
+}
+
+broadcast_uses = {
+    broadcast_use+
 }
 
 broadcast_use = {

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -2018,3 +2018,46 @@ mod m4 {
     } // verus!
     "###);
 }
+
+#[test]
+fn verus_broadcast_uses_trailing_newline() {
+    let file = r###"
+verus! {
+proof fn to_multiset_build<A>(s: Seq<A>, a: A)
+    ensures
+        s.push(a).to_multiset() =~= s.to_multiset().insert(a),
+    decreases s.len(),
+{
+    broadcast use crate::multiset::multiset_axioms;
+    /* xx */
+    broadcast use crate::multiset::multiset_stuffs;
+    // xx
+    broadcast use crate::useful;
+    broadcast use crate::moreuseful;
+    if s.len() == 0 {
+    }
+}
+} // verus!
+"###;
+    assert_snapshot!(parse_and_format(file).unwrap(), @r###"
+    verus! {
+
+    proof fn to_multiset_build<A>(s: Seq<A>, a: A)
+        ensures
+            s.push(a).to_multiset() =~= s.to_multiset().insert(a),
+        decreases s.len(),
+    {
+        broadcast use crate::multiset::multiset_axioms;
+        /* xx */
+        broadcast use crate::multiset::multiset_stuffs;
+        // xx
+        broadcast use crate::useful;
+        broadcast use crate::moreuseful;
+
+        if s.len() == 0 {
+        }
+    }
+
+    } // verus!
+    "###);
+}

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -1990,6 +1990,7 @@ mod m4 {
                 p.inv(),
         {
             broadcast use Ring::properties;
+
             assert(p.spec_succ().spec_prev() == p);
             assert(p.spec_prev().spec_succ() == p);
         }


### PR DESCRIPTION
Adds an extra trailing newline for `broadcast use` groups, exemplified by this diff:
<img width="642" alt="image" src="https://github.com/verus-lang/verusfmt/assets/5683582/d7d70ee4-2c9a-4cf0-b642-23eb8ea1c3c5">

Essentially, this PR handles the situation brought up by @utaal-b in #53. To lead to good output, this required handling a few special cases:
- presence of multiple `broadcast use` items in the same fn
- comments between those items
- top-level `broadcast use` items

I've handled each of these cases to produce good output. Additionally, the snapshot test in this is is an expanded version of what @utaal-b proposed in #53.

---

**NOTE:** This PR causes an update to the vstd snapshot. This is intentional (due to style change), but will require coordination on https://github.com/verus-lang/verus when the new version of verusfmt is released. This should not block merging _this_ PR, but yeah, from a release standpoint, will need some coordination to prevent CI failures. I'll open a PR there soon.