### PR TITLE
Give the snapshot tests extra stack space to run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +599,19 @@ name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
+]
 
 [[package]]
 name = "strsim"
@@ -831,6 +853,7 @@ dependencies = [
  "pretty",
  "regex",
  "similar",
+ "stacker",
  "tempfile",
  "thiserror",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ tracing-subscriber = { version = "0.3.17" }
 insta = { version = "1.30.0" }
 similar = { version = "2.2.1" }
 glob = "0.3.1"
+stacker = "0.1.15"
 
 # Spend more time on initial compilation in exchange for faster runs
 [profile.dev.package.insta]

--- a/tests/snapshot-examples.rs
+++ b/tests/snapshot-examples.rs
@@ -4,12 +4,19 @@
 //! quick indicator for whether files in `../examples/` (such as `../examples/syntax.rs`) have been
 //! modified by any change.
 
+fn verusfmt_run_with_extra_stack(s: &str, opts: verusfmt::RunOptions) -> miette::Result<String> {
+    #[allow(non_upper_case_globals)]
+    const MiB: usize = 1024 * 1024;
+    const STACK_SIZE: usize = 8 * MiB;
+    stacker::grow(STACK_SIZE, || verusfmt::run(s, opts))
+}
+
 fn check_snapshot(original: &str) {
     check_snapshot_with_config(original, Default::default())
 }
 
 fn check_snapshot_with_config(original: &str, config: verusfmt::RunOptions) {
-    let formatted = verusfmt::run(original, config).unwrap();
+    let formatted = verusfmt_run_with_extra_stack(original, config).unwrap();
     if original != formatted {
         let diff = similar::udiff::unified_diff(
             similar::Algorithm::Patience,


### PR DESCRIPTION
This updates the snapshot tests to have some extra room on the stack, making it less likely that the snapshot tests fail.

In the longer term, we probably want to use [`stacker::maybe_grow`](https://docs.rs/stacker/latest/stacker/fn.maybe_grow.html) at well-chosen points in the `to_doc` recursion, but we should do that only if we see a stack overflow happen in-the-wild, and not in the somewhat-contrived test setup for our larger snapshots (which already overly nest things due to all the modules being inlined into one file via [`inline-crate`](https://github.com/jaybosamiya/inline-crate/).

The other alternative to this PR would be to remove the single-file snapshots, and make them more like how we just store vstd itself.

For now, this is a blocker to https://github.com/verus-lang/verusfmt/pull/62 where a snapshot test fails due to lack of sufficient stack space.