### PR TITLE
Support `const-arg` grammar rule

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -799,7 +799,7 @@ fn to_doc<'a>(
         Rule::type_arg => map_to_doc(ctx, arena, pair),
         Rule::assoc_type_arg => unsupported(pair),
         Rule::lifetime_arg => map_to_doc(ctx, arena, pair),
-        Rule::const_arg => unsupported(pair),
+        Rule::const_arg => map_to_doc(ctx, arena, pair),
         Rule::generic_args_binding => map_to_doc(ctx, arena, pair),
         Rule::calc_macro_reln => s,
         Rule::calc_macro_body => {

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -2239,7 +2239,6 @@ fn bar() {
     "###);
 }
 
-
 #[test]
 fn verus_const_arg() {
     let file = r#"

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -2238,3 +2238,29 @@ fn bar() {
     } // verus!
     "###);
 }
+
+
+#[test]
+fn verus_const_arg() {
+    let file = r#"
+verus! {
+
+fn foo(arg: ConstBytes<2>) -> (res: ConstBytes<4>) {
+    let x: ConstBytes<3> = bar();
+    baz();
+}
+    
+}
+
+"#;
+    assert_snapshot!(parse_and_format(file).unwrap(), @r###"
+    verus! {
+
+    fn foo(arg: ConstBytes<2>) -> (res: ConstBytes<4>) {
+        let x: ConstBytes<3> = bar();
+        baz();
+    }
+
+    } // verus!
+    "###);
+}


### PR DESCRIPTION
For const generic arguments, e.g.:

```
fn foo(arg: ConstBytes<2>) -> (res: ConstBytes<4>) {
    let x: ConstBytes<3> = bar();
    baz();
}
```

I added a small test.