### PR TITLE
Automatic formatting for the `seq!` macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Support automatic formatting of the `seq!` macro
+
 # v0.3.4
 
 * Support const generic arguments

--- a/examples/pagetable.rs
+++ b/examples/pagetable.rs
@@ -9348,13 +9348,12 @@ pub proof fn axiom_x86_arch_exec_spec()
 
 pub exec fn x86_arch_exec() -> (res: ArchExec)
     ensures
-        res.layers@
-            == seq![
-                ArchLayerExec { entry_size: L0_ENTRY_SIZE, num_entries: 512 },
-                ArchLayerExec { entry_size: L1_ENTRY_SIZE, num_entries: 512 },
-                ArchLayerExec { entry_size: L2_ENTRY_SIZE, num_entries: 512 },
-                ArchLayerExec { entry_size: L3_ENTRY_SIZE, num_entries: 512 },
-            ],
+        res.layers@ == seq![
+            ArchLayerExec { entry_size: L0_ENTRY_SIZE, num_entries: 512 },
+            ArchLayerExec { entry_size: L1_ENTRY_SIZE, num_entries: 512 },
+            ArchLayerExec { entry_size: L2_ENTRY_SIZE, num_entries: 512 },
+            ArchLayerExec { entry_size: L3_ENTRY_SIZE, num_entries: 512 },
+        ],
         res@ === x86_arch_spec,
         res === x86_arch_exec_spec(),
 {
@@ -9376,13 +9375,12 @@ pub exec fn x86_arch_exec() -> (res: ArchExec)
 }
 
 pub spec const x86_arch_spec: Arch = Arch {
-    layers:
-        seq![
-            ArchLayer { entry_size: L0_ENTRY_SIZE as nat, num_entries: 512 },
-            ArchLayer { entry_size: L1_ENTRY_SIZE as nat, num_entries: 512 },
-            ArchLayer { entry_size: L2_ENTRY_SIZE as nat, num_entries: 512 },
-            ArchLayer { entry_size: L3_ENTRY_SIZE as nat, num_entries: 512 },
-        ],
+    layers: seq![
+        ArchLayer { entry_size: L0_ENTRY_SIZE as nat, num_entries: 512 },
+        ArchLayer { entry_size: L1_ENTRY_SIZE as nat, num_entries: 512 },
+        ArchLayer { entry_size: L2_ENTRY_SIZE as nat, num_entries: 512 },
+        ArchLayer { entry_size: L3_ENTRY_SIZE as nat, num_entries: 512 },
+    ],
 };
 
 } // verus!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -646,7 +646,7 @@ fn to_doc<'a>(
         | Rule::underscore_str
         | Rule::arrow_expr_str => s,
         Rule::fn_traits | Rule::impl_str => s,
-        Rule::calc_str => s,
+        Rule::calc_str | Rule::seq_str => s,
         Rule::pipe_str => docs!(arena, arena.line(), s, arena.space()),
         //        Rule::triple_and |
         //        Rule::triple_or =>
@@ -838,11 +838,12 @@ fn to_doc<'a>(
             ))
         }
         Rule::calc_macro_call => map_to_doc(ctx, arena, pair),
+        Rule::seq_macro_call => map_to_doc(ctx, arena, pair),
         Rule::macro_call | Rule::macro_call_stmt => {
             if pair
                 .clone()
                 .into_inner()
-                .any(|x| matches!(x.as_rule(), Rule::calc_macro_call))
+                .any(|x| matches!(x.as_rule(), Rule::calc_macro_call | Rule::seq_macro_call))
             {
                 map_to_doc(ctx, arena, pair)
             } else {

--- a/src/verus.pest
+++ b/src/verus.pest
@@ -498,12 +498,12 @@ calc_macro_body = {
 }
 
 calc_macro_call = {
-    attr* ~ calc_str ~ bang_str ~ !"=" ~
+    attr* ~ calc_str ~ bang_str ~
     calc_macro_body
 }
 
 seq_macro_call = {
-    attr* ~ seq_str ~ bang_str ~ !"=" ~
+    attr* ~ seq_str ~ bang_str ~
     lbracket_str ~ comma_delimited_exprs? ~ rbracket_str
 }
 

--- a/src/verus.pest
+++ b/src/verus.pest
@@ -312,6 +312,7 @@ return_str = ${ "return" ~ !("_" | ASCII_ALPHANUMERIC) }
 r_str = ${ "r" ~ !("_" | ASCII_ALPHANUMERIC) }
 Self_str = ${ "Self" ~ !("_" | ASCII_ALPHANUMERIC) }
 self_str = ${ "self" ~ !("_" | ASCII_ALPHANUMERIC) }
+seq_str = ${ "seq" ~ !("_" | ASCII_ALPHANUMERIC) }
 sizeof_str = ${ "size_of" ~ !("_" | ASCII_ALPHANUMERIC) }
 spec_fn_str = ${ "spec_fn" ~ !("_" | ASCII_ALPHANUMERIC) }
 spec_str = ${ "spec" ~ !("_" | ASCII_ALPHANUMERIC) }
@@ -501,9 +502,15 @@ calc_macro_call = {
     calc_macro_body
 }
 
+seq_macro_call = {
+    attr* ~ seq_str ~ bang_str ~ !"=" ~
+    lbracket_str ~ comma_delimited_exprs? ~ rbracket_str
+}
+
 // TODO: Special handling for the state_machine! macros?
 macro_call = {
     calc_macro_call
+  | seq_macro_call
   | attr* ~ path ~ bang_str ~ !"=" ~ token_tree
 }
 

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -2263,3 +2263,50 @@ fn foo(arg: ConstBytes<2>) -> (res: ConstBytes<4>) {
     } // verus!
     "###);
 }
+
+#[test]
+fn verus_seq_macro() {
+    let file = r#"
+verus! {
+proof fn f() {
+    let s = seq![
+        0x00,        0x00,        0x00,        0x00,        0x00,        0x00,
+        0x00,        0x00,        0x00,        0x00,
+        0x00,        0x00,        0x00,
+        0x00,        0x00,        0x00,
+    ];
+    let s = seq![
+        0x00,       0x00,
+        0x00, 0x00,
+    ];
+}
+}
+"#;
+    assert_snapshot!(parse_and_format(file).unwrap(), @r###"
+    verus! {
+
+    proof fn f() {
+        let s = seq![
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+        ];
+        let s = seq![0x00, 0x00, 0x00, 0x00];
+    }
+
+    } // verus!
+    "###);
+}


### PR DESCRIPTION
Fairly straightforward implementation of the `seq!` macro by reusing the comma-delimited-exprs. When everything within a `seq` fits on a single line, it places it on single line, otherwise each element gets its own line.

CC @mmcloughlin because of https://github.com/verus-lang/verusfmt/issues/42