### PR TITLE
Fix parsing blank function qualifiers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Support parsing blank function qualifiers(ensures, acquires, decreases, etc.).
+* Support parsing empty requires/ensures/... clauses
 
 # v0.3.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Support parsing blank function qualifiers(ensures, acquires, decreases, etc.).
+
 # v0.3.5
 
 * Fix incorrect parsing of string literals containing "verus!{"

--- a/src/verus.pest
+++ b/src/verus.pest
@@ -1678,7 +1678,7 @@ comma_delimited_exprs = {
 //    }
 // where we could interpret the ensures expression as `a == b { a }`
 comma_delimited_exprs_for_verus_clauses = {
-    expr_no_struct ~ ("," ~ !verus_clause_non_expr ~ expr_no_struct)* ~ ","?
+    !verus_clause_non_expr ~ expr_no_struct ~ ("," ~ !verus_clause_non_expr ~ expr_no_struct)* ~ ","?
 }
 
 groupable_comma_delimited_exprs_for_verus_clauses = {
@@ -1700,31 +1700,31 @@ verus_clause_non_expr = _{
 }
 
 requires_clause = {
-    requires_str ~ comma_delimited_exprs_for_verus_clauses
+    requires_str ~ comma_delimited_exprs_for_verus_clauses?
 }
 
 ensures_clause = {
-    ensures_str ~ comma_delimited_exprs_for_verus_clauses
+    ensures_str ~ comma_delimited_exprs_for_verus_clauses?
 }
 
 invariant_except_break_clause = {
-    invariant_except_break_str ~ comma_delimited_exprs_for_verus_clauses
+    invariant_except_break_str ~ comma_delimited_exprs_for_verus_clauses?
 }
 
 invariant_clause = {
-    invariant_str ~ comma_delimited_exprs_for_verus_clauses
+    invariant_str ~ comma_delimited_exprs_for_verus_clauses?
 }
 
 invariant_ensures_clause = {
-    invariant_ensures_str ~ comma_delimited_exprs_for_verus_clauses
+    invariant_ensures_str ~ comma_delimited_exprs_for_verus_clauses?
 }
 
 recommends_clause = {
-    recommends_str ~ comma_delimited_exprs_for_verus_clauses ~ (via_str ~ expr_no_struct)?
+    recommends_str ~ (comma_delimited_exprs_for_verus_clauses ~ (via_str ~ expr_no_struct)?)?
 }
 
 decreases_clause = {
-    decreases_str ~ groupable_comma_delimited_exprs_for_verus_clauses ~ (when_str ~ expr_no_struct)? ~ (via_str ~ expr_no_struct)?
+    decreases_str ~ (groupable_comma_delimited_exprs_for_verus_clauses ~ (when_str ~ expr_no_struct)? ~ (via_str ~ expr_no_struct)?)?
 }
 
 unwind_clause = {

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -2310,3 +2310,55 @@ proof fn f() {
     } // verus!
     "###);
 }
+
+#[test]
+fn verus_empty_fn_quanlifier_expr() {
+    let file = r#"
+verus! {
+    fn test0()
+        requires
+            i = 0
+        ensures
+    {}
+    fn test1()
+        requires
+            i = 0
+        ensures
+        recommends
+    {}
+    fn test2()
+        requires
+        ensures
+            i = 0
+    {}
+}
+"#;
+
+    assert_snapshot!(parse_and_format(file).unwrap(), @r###"
+    verus! {
+
+    fn test0()
+        requires
+            i = 0,
+        ensures
+    {
+    }
+
+    fn test1()
+        requires
+            i = 0,
+        ensures
+        recommends
+    {
+    }
+
+    fn test2()
+        requires
+        ensures
+            i = 0,
+    {
+    }
+
+    } // verus!
+    "###);
+}


### PR DESCRIPTION
verus allows declare blank function qualifiers(ensures, requires, recommends, etc.) and this is commonly used when debugging a proof.

For example, the following two cases are allowed in verus:

```
fn foo()
    ensures
    requires
    {}
fn bar()
   ensures
        // i = 1,
   requires
   {}
```

The current formatter cannot parse the above two examples because the qualifier clause expects the qualifier keywords followed by one or more comma delimited expression(s).

Only making `comma_delimited_exprs_for_verus_clauses` an optional match cannot resolve the issue because Pest greedily matches the following qualifier with `expr_no_struct`.

Increasing the precedency of all the qualifier keywords might work.(?) But instead, this patch explicitly excludes any qualifier keywords from `comma_delimited_exprs_for_verus_clauses` so if the qualifier is blank, Pest will not match the following tokens with the comma delimited expression.

A test case that would otherwise fail without this patch is provided in `tests/verus-consistency.rs`.