### PR TITLE
Support older powershell

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We support multiple install methods. Get the [latest release](https://github.com
   + <details><summary>Windows (click to expand)</summary>
 
     ```sh
-    irm https://github.com/verus-lang/verusfmt/releases/latest/download/verusfmt-installer.ps1 | iex
+    powershell.exe -ExecutionPolicy RemoteSigned -c "irm https://github.com/verus-lang/verusfmt/releases/latest/download/verusfmt-installer.ps1 | iex"
     ```
     </details>
 


### PR DESCRIPTION
Updates pre-built binary installation instructions to support both PowerShell 5.x (default on Windows 11), as well as latest (7.x). Prior instructions were tested and work fine on 7.x, but cause 5.x to immediately exit when you paste it. 

As far as I can tell, 6.x onwards is when things changed to the new behavior that doesn't need to set the ExecutionPolicy. Nonetheless, the updated instructions have now been tested to work on both 5.1.22621.3880 and 7.4.3.