### PR TITLE
Fix minor min-parsing issues

### DIFF
--- a/src/verus-minimal.pest
+++ b/src/verus-minimal.pest
@@ -45,6 +45,10 @@ raw_byte_string = @{
   "b" ~ raw_string
 }
 
+char = @{
+    "'" ~ ("\\'" | !"'" ~ ANY) ~ "'"
+}
+
 multiline_comment = @{
     "/*" ~ (multiline_comment | (!"*/" ~ ANY))* ~ "*/"
 }
@@ -59,7 +63,7 @@ file = {
 
 /// Region of code that doesn't contain any Verus macro use whatsoever
 non_verus = @{
-  (!("verus" ~ WHITESPACE* ~ "!" ~ WHITESPACE* ~ "{") ~ (string | raw_string | byte_string | raw_byte_string | ANY))*
+  (!("verus" ~ WHITESPACE* ~ "!" ~ WHITESPACE* ~ "{") ~ (string | raw_string | byte_string | raw_byte_string | char | ANY))*
 }
 
 /// An actual use of the `verus! { ... }` macro
@@ -90,5 +94,5 @@ paren_tree = {
 
 /// _Technically_ not a Rust token, but we're trying to do a minimal parser _anyways_
 token = {
-    !("{" | "}" | "[" | "]" | "(" | ")") ~ ANY
+    !("{" | "}" | "[" | "]" | "(" | ")") ~ (string | raw_string | byte_string | raw_byte_string | char | ANY)
 }

--- a/src/verus-minimal.pest
+++ b/src/verus-minimal.pest
@@ -59,12 +59,12 @@ file = {
 
 /// Region of code that doesn't contain any Verus macro use whatsoever
 non_verus = @{
-  (!("verus!" ~ WHITESPACE* ~ "{") ~ (string | raw_string | byte_string | raw_byte_string | ANY))*
+  (!("verus" ~ WHITESPACE* ~ "!" ~ WHITESPACE* ~ "{") ~ (string | raw_string | byte_string | raw_byte_string | ANY))*
 }
 
 /// An actual use of the `verus! { ... }` macro
 verus_macro_use = ${
-    "verus!" ~ WHITESPACE* ~ "{" ~ (WHITESPACE | COMMENT)* ~ verus_macro_body ~ (WHITESPACE | COMMENT)* ~ "}" ~ WHITESPACE* ~ ("//" ~ WHITESPACE* ~ "verus!" ~ WHITESPACE*)?
+    "verus" ~ WHITESPACE* ~ "!" ~ WHITESPACE* ~ "{" ~ (WHITESPACE | COMMENT)* ~ verus_macro_body ~ (WHITESPACE | COMMENT)* ~ "}" ~ WHITESPACE* ~ ("//" ~ WHITESPACE* ~ "verus" ~ WHITESPACE* ~ "!" ~ WHITESPACE*)?
 }
 
 /// Anything inside the `verus! { ... }` macro

--- a/src/verus.pest
+++ b/src/verus.pest
@@ -82,12 +82,12 @@ file = {
 /// happens, then we need to make sure that we aren't accidentally starting
 /// parsing in the middle of the macro_rules macro body itself. Similarly, strings.
 non_verus = @{
-  (!("verus!" ~ WHITESPACE* ~ "{") ~ (macro_rules | string | raw_string | byte_string | raw_byte_string | ANY))*
+  (!("verus" ~ WHITESPACE* ~ "!" ~ WHITESPACE* ~ "{") ~ (macro_rules | string | raw_string | byte_string | raw_byte_string | ANY))*
 }
 
 /// An actual use of the `verus! { ... }` macro
 verus_macro_use = ${
-    "verus!" ~ WHITESPACE* ~ "{" ~ (WHITESPACE | COMMENT)* ~ verus_macro_body ~ (WHITESPACE | COMMENT)* ~ "}" ~ WHITESPACE* ~ ("//" ~ WHITESPACE* ~ "verus!")?
+    "verus" ~ WHITESPACE* ~ "!" ~ WHITESPACE* ~ "{" ~ (WHITESPACE | COMMENT)* ~ verus_macro_body ~ (WHITESPACE | COMMENT)* ~ "}" ~ WHITESPACE* ~ ("//" ~ WHITESPACE* ~ "verus" ~ WHITESPACE* ~ "!")?
 }
 
 /// Anything inside the `verus! { ... }` macro


### PR DESCRIPTION
Hit some issues when attempting to run verusfmt on https://github.com/secure-foundations/human-eval-verus/blob/main/tasks/human_eval_001.rs ; specifically, our minimal parser would consider the parenthesis in `'('` to be syntactically-relevant, rather than ignore it, thereby causing a:
```
thread 'main' panicked at src/rustfmt.rs:51:10:
Minimal parsing should never fail. If it did, please report this as an error.: Error { variant: ParsingError { positives: [COMMENT, tt], negatives: [] }, location: Pos(5984), line_col: Pos((155, 9)), path: None, line: "        } else if c == ')' {", continued_line: None }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This PR fixes the issues.

Automatically-minimized example that triggers the issue before this PR:
```rs
verus! {

fn a()
    ensures
{
    {
        if '(' {
            if 0 {
            }
        }
    }
}

} // verus!
```