### PR TITLE
Improved handling of comments around clauses/stanzas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+* Improved handling of comments around clauses/stanzas
+  - Each comment now maintains loyalty to the clause the user picked it to stay with, rather than automatically migrating to the previous clause in the presence of `assert ... by { ... }`-style constructs
+
 # v0.4.1
 
 * Minor fix to prevent panic on formatting files containing unbalanced parentheses in strings/chars/...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -562,8 +562,18 @@ fn terminal_expr(pairs: &Pairs<Rule>) -> bool {
 }
 
 fn debug_print(pair: Pair<Rule>, indent: usize) {
-    print!("{:indent$}{:?} {{", "", pair.as_rule(), indent = indent);
-    let pairs = pair.into_inner();
+    if pair.as_rule() == Rule::COMMENT {
+        print!(
+            "{:indent$}{:?} {{ {comment:?} ",
+            "",
+            pair.as_rule(),
+            indent = indent,
+            comment = pair.as_str()
+        );
+    } else {
+        print!("{:indent$}{:?} {{", "", pair.as_rule(), indent = indent);
+    }
+    let pairs = pair.clone().into_inner();
     if pairs.peek().is_some() {
         println!();
         pairs.for_each(|p| debug_print(p, indent + 2));

--- a/src/verus.pest
+++ b/src/verus.pest
@@ -988,7 +988,11 @@ stmt = !{
   | proof_block
   | let_stmt
   | assignment_stmt
-  | expr_with_block ~ semi_str?
+  // We can't use `expr_with_block ~ semi_str?` here, and instead need to do it
+  // as the two separate ordered alternatives (`ewb ~ semi_str | ewb`) to
+  // prevent munching of multi-newlines that happens otherwise
+  | expr_with_block ~ semi_str
+  | expr_with_block
   | expr ~ semi_str
   | item_no_macro_call
   | macro_call_stmt

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -2453,6 +2453,36 @@ fn fff() {
     baz;
 }
 
+pub fn foo() {
+    // this should stay stuck to the `a`
+    assert(a) by {
+        // whatever
+    }
+    // this should also stay stuck to the `a`
+    // and so should this line
+
+    // but this line
+    // and this line should stick to the `b`
+    b;
+    // and this comment should also stick to the `b`
+
+    // similarly `c`
+    c;
+    // `c` again
+
+    // and an empty comment stands alone
+
+    // similarly `d`
+    d;
+    // `d` again
+
+    // and finally, `d`
+    assert(d) by {
+        // whatever
+    }
+    // well, now done with `d`
+}
+
 } // verus!
 "#;
 
@@ -2468,6 +2498,36 @@ fn fff() {
 
         bar;
         baz;
+    }
+
+    pub fn foo() {
+        // this should stay stuck to the `a`
+        assert(a) by {
+            // whatever
+        }
+        // this should also stay stuck to the `a`
+        // and so should this line
+
+        // but this line
+        // and this line should stick to the `b`
+        b;
+        // and this comment should also stick to the `b`
+
+        // similarly `c`
+        c;
+        // `c` again
+
+        // and an empty comment stands alone
+
+        // similarly `d`
+        d;
+        // `d` again
+
+        // and finally, `d`
+        assert(d) by {
+            // whatever
+        }
+        // well, now done with `d`
     }
 
     } // verus!


### PR DESCRIPTION
With this PR, each comment now maintains loyalty to the clause the user picked it to stay with, rather than automatically migrating to the previous clause in the presence of `assert ... by { ... }`-style constructs.  

See the newly introduced test which would fail before this PR.