### PR TITLE
Support the `macro_pat` parsing object

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1315,7 +1315,7 @@ fn to_doc<'a>(
         Rule::path_pat => map_to_doc(ctx, arena, pair),
         Rule::box_pat => map_to_doc(ctx, arena, pair),
         Rule::rest_pat => map_to_doc(ctx, arena, pair),
-        Rule::macro_pat => unsupported(pair),
+        Rule::macro_pat => map_to_doc(ctx, arena, pair), // unsupported(pair),
         Rule::const_block_pat => unsupported(pair),
 
         //************************//

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1315,7 +1315,7 @@ fn to_doc<'a>(
         Rule::path_pat => map_to_doc(ctx, arena, pair),
         Rule::box_pat => map_to_doc(ctx, arena, pair),
         Rule::rest_pat => map_to_doc(ctx, arena, pair),
-        Rule::macro_pat => map_to_doc(ctx, arena, pair), // unsupported(pair),
+        Rule::macro_pat => map_to_doc(ctx, arena, pair),
         Rule::const_block_pat => unsupported(pair),
 
         //************************//

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -484,7 +484,13 @@ verus!{
         cong;
         done;
     ");
-
+    fn foo(x: usize) {
+        match x {
+            inj_ord_choice_pat!((_,x), *, *) => (),
+            inj_ord_choice_pat!(*, (_,x), *) => (),
+            inj_ord_choice_pat!(*, *, _) => (),
+        };
+    }
 }
 "#;
 
@@ -505,6 +511,14 @@ verus!{
             cong;
             done;
         ");
+    
+    fn foo(x: usize) {
+        match x {
+            inj_ord_choice_pat!((_,x), *, *) => (),
+            inj_ord_choice_pat!(*, (_,x), *) => (),
+            inj_ord_choice_pat!(*, *, _) => (),
+        };
+    }
 
     } // verus!
     "###);


### PR DESCRIPTION
In [Vest](https://github.com/secure-foundations/vest) there is the [macro `inj_ord_choice_pat!`](https://github.com/secure-foundations/vest/blob/becaca36a94cd38868e770ecbe0db295ffabd62b/vest/src/regular/choice.rs#L255-L270) which uses the `pat` capture for `macro_rules!` macros. Currently `verusfmt` fails on uses of this macro `ERROR Unsupported parsing object 'macro_pat'`. 

This PR adds support for this parsing object. I added a small test to the Verus consistency tests. Happy to change or move the test as necessary.