### PR TITLE
Make axoupdater an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [dependencies]
-axoupdater = { version = "0.7.2", features = ["blocking", "github_releases"], default-features = false }
+axoupdater = { version = "0.7.2", features = ["blocking", "github_releases"], default-features = false, optional = true }
 clap = { version = "4.3.11", features = ["derive"] }
 fs-err = "3.0.0"
 miette = { version = "7.2.0", features = ["fancy"] }
@@ -38,6 +38,13 @@ insta = { version = "1.30.0" }
 similar = { version = "2.2.1" }
 stacker = "0.1.15"
 glob-macro = { path = "glob-macro" }
+
+[features]
+# We enable the "optional" dependencies, that are only necessary for the binary,
+# as default-enabled features. If verusfmt is being used as a library, then that
+# program can turn default features off in order to obtain a more stripped-down
+# version of the library.
+default = ["axoupdater"]
 
 # Spend more time on initial compilation in exchange for faster runs
 [profile.dev.package.insta]


### PR DESCRIPTION
As in title; see comment in Cargo.toml as well as #107.  Basically, with this PR, users of verusfmt _as a library_ can use `default-features = false` to obtain a stripped down version that doesn't inlcude `axoupdater` as a dependency.

Closes #107