### PR TITLE
Support the `axiom` keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add support for backslashed character literals (e.g., `\t`, `\\`, `\u{00e9}`, etc.)
 * Add support for `uninterp`reted spec functions (see [verus#1473](https://github.com/verus-lang/verus/pull/1473))
+* Add support for the `axiom` syntax (see [verus#1518](https://github.com/verus-lang/verus/pull/1518))
 
 # v0.5.3
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -784,6 +784,7 @@ fn to_doc<'a>(
         | Rule::assert_str
         | Rule::assume_str
         | Rule::assume_specification_str
+        | Rule::axiom_str
         | Rule::checked_str
         | Rule::choose_str
         | Rule::exec_str

--- a/src/verus.pest
+++ b/src/verus.pest
@@ -254,6 +254,7 @@ async_str = ${ "async" ~ !("_" | ASCII_ALPHANUMERIC) }
 as_str = ${ "as" ~ !("_" | ASCII_ALPHANUMERIC) }
 auto_str = ${ "auto" ~ !("_" | ASCII_ALPHANUMERIC) }
 await_str = ${ "await" ~ !("_" | ASCII_ALPHANUMERIC) }
+axiom_str = ${ "axiom" ~ !("_" | ASCII_ALPHANUMERIC) }
 box_str = ${ "box" ~ !("_" | ASCII_ALPHANUMERIC) }
 break_str = ${ "break" ~ !("_" | ASCII_ALPHANUMERIC) }
 broadcast_str = ${ "broadcast" ~ !("_" | ASCII_ALPHANUMERIC) }
@@ -1732,6 +1733,7 @@ fn_mode = {
   | spec_str
   | proof_str
   | exec_str
+  | axiom_str
 }
 
 mode_spec_checked = {

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -2833,3 +2833,20 @@ verus! { pub uninterp   spec fn bar() -> bool   ; }
     } // verus!
     ")
 }
+
+#[test]
+fn verus_axiom_functions() {
+    let file = r#"
+verus! { pub axiom fn foo(x: u8) requires x == 5; }
+"#;
+    assert_snapshot!(parse_and_format(file).unwrap(), @r"
+    verus! {
+
+    pub axiom fn foo(x: u8)
+        requires
+            x == 5,
+    ;
+
+    } // verus!
+    ")
+}


### PR DESCRIPTION
See https://github.com/verus-lang/verus/pull/1518

We need to wait till decisions are made for the above PR as to whether we are actually planning on having it in Verus, but assuming we are, this PR is readying up the verusfmt changes needed.