### PR TITLE
Support for `uninterp`reted spec functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Add support for backslashed character literals (e.g., `\t`, `\\`, `\u{00e9}`, etc.)
+* Add support for `uninterp`reted spec functions (see [verus#1473](https://github.com/verus-lang/verus/pull/1473))
 
 # v0.5.3
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -742,6 +742,7 @@ fn to_doc<'a>(
         | Rule::u32_str
         | Rule::u64_str
         | Rule::u8_str
+        | Rule::uninterp_str
         | Rule::union_str
         | Rule::unsafe_str
         | Rule::use_str

--- a/src/verus.pest
+++ b/src/verus.pest
@@ -351,6 +351,7 @@ u16_str = ${ "u16" ~ !("_" | ASCII_ALPHANUMERIC) }
 u32_str = ${ "u32" ~ !("_" | ASCII_ALPHANUMERIC) }
 u64_str = ${ "u64" ~ !("_" | ASCII_ALPHANUMERIC) }
 u8_str = ${ "u8" ~ !("_" | ASCII_ALPHANUMERIC) }
+uninterp_str = ${ "uninterp" ~ !("_" | ASCII_ALPHANUMERIC) }
 union_str = ${ "union" ~ !("_" | ASCII_ALPHANUMERIC) }
 unsafe_str = ${ "unsafe" ~ !("_" | ASCII_ALPHANUMERIC) }
 use_str = ${ "use" ~ !("_" | ASCII_ALPHANUMERIC) }
@@ -1723,6 +1724,7 @@ const_block_pat = {
 publish = {
     closed_str
   | open_str
+  | uninterp_str
 }
 
 fn_mode = {

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -2819,3 +2819,17 @@ proof fn uses_spec_is(t: ThisOrThat)
     } // verus!
     ")
 }
+
+#[test]
+fn verus_uninterp_spec_functions() {
+    let file = r#"
+verus! { pub uninterp   spec fn bar() -> bool   ; }
+"#;
+    assert_snapshot!(parse_and_format(file).unwrap(), @r"
+    verus! {
+
+    pub uninterp spec fn bar() -> bool;
+
+    } // verus!
+    ")
+}


### PR DESCRIPTION
See https://github.com/verus-lang/verus/pull/1473