### PR TITLE
Update to Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verusfmt"
 version = "0.5.3"
-edition = "2021"
+edition = "2024"
 autoexamples = false
 license = "MIT"
 description = "An opinionated formatter for Verus"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
 mod rustfmt;
 
-pub use crate::rustfmt::{rustfmt, RustFmtConfig};
+pub use crate::rustfmt::{RustFmtConfig, rustfmt};
 
-use pest::{iterators::Pair, iterators::Pairs, Parser};
+use pest::{Parser, iterators::Pair, iterators::Pairs};
 use pest_derive::Parser;
 use pretty::*;
 use regex::Regex;
 use std::collections::HashSet;
-use tracing::{debug, enabled, error, info, Level};
+use tracing::{Level, debug, enabled, error, info};
 
 #[derive(Parser)]
 #[grammar = "verus.pest"]
@@ -543,11 +543,7 @@ fn expr_only_block(r: Rule, pairs: &Pairs<Rule>) -> bool {
                 Rule::expr => {
                     // We don't want to treat a triple expr as an expr only block,
                     // since that would result in it being grouped with its surrounding braces
-                    if is_prefix_triple(p.clone()) {
-                        1
-                    } else {
-                        -1
-                    }
+                    if is_prefix_triple(p.clone()) { 1 } else { -1 }
                 }
                 _ => 0,
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use clap::{Parser as ClapParser, ValueEnum};
 use fs_err as fs;
-use miette::{miette, IntoDiagnostic};
+use miette::{IntoDiagnostic, miette};
 use tracing::{error, info}; // debug, trace, warn
 use verusfmt::RustFmtConfig;
 

--- a/src/rustfmt.rs
+++ b/src/rustfmt.rs
@@ -4,7 +4,7 @@
 use std::io::Write;
 use std::process::{Command, Stdio};
 
-use pest::{iterators::Pair, Parser};
+use pest::{Parser, iterators::Pair};
 use pest_derive::Parser;
 
 use fs_err as fs;

--- a/tests/rustfmt-matching.rs
+++ b/tests/rustfmt-matching.rs
@@ -1,4 +1,4 @@
-use verusfmt::{rustfmt, VERUS_PREFIX, VERUS_SUFFIX};
+use verusfmt::{VERUS_PREFIX, VERUS_SUFFIX, rustfmt};
 
 /// Tests to check that when formatting standard Rust syntax,
 /// we match rustfmt


### PR DESCRIPTION
Turns out the only difference between 2021 and 2024 edition for this repo is formatting (heh!). While we don't _need_ to update to the latest edition, the formatting style used by the 2024 edition is slightly better, so this PR just updates things to that.

This does NOT impact the output of verusfmt at all and is instead only a change at the _source_ of verusfmt.