### PR TITLE
Revert "Update to Rust 2024 edition"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verusfmt"
 version = "0.5.3"
-edition = "2024"
+edition = "2021"
 autoexamples = false
 license = "MIT"
 description = "An opinionated formatter for Verus"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
 mod rustfmt;
 
-pub use crate::rustfmt::{RustFmtConfig, rustfmt};
+pub use crate::rustfmt::{rustfmt, RustFmtConfig};
 
-use pest::{Parser, iterators::Pair, iterators::Pairs};
+use pest::{iterators::Pair, iterators::Pairs, Parser};
 use pest_derive::Parser;
 use pretty::*;
 use regex::Regex;
 use std::collections::HashSet;
-use tracing::{Level, debug, enabled, error, info};
+use tracing::{debug, enabled, error, info, Level};
 
 #[derive(Parser)]
 #[grammar = "verus.pest"]
@@ -543,7 +543,11 @@ fn expr_only_block(r: Rule, pairs: &Pairs<Rule>) -> bool {
                 Rule::expr => {
                     // We don't want to treat a triple expr as an expr only block,
                     // since that would result in it being grouped with its surrounding braces
-                    if is_prefix_triple(p.clone()) { 1 } else { -1 }
+                    if is_prefix_triple(p.clone()) {
+                        1
+                    } else {
+                        -1
+                    }
                 }
                 _ => 0,
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use clap::{Parser as ClapParser, ValueEnum};
 use fs_err as fs;
-use miette::{IntoDiagnostic, miette};
+use miette::{miette, IntoDiagnostic};
 use tracing::{error, info}; // debug, trace, warn
 use verusfmt::RustFmtConfig;
 

--- a/src/rustfmt.rs
+++ b/src/rustfmt.rs
@@ -4,7 +4,7 @@
 use std::io::Write;
 use std::process::{Command, Stdio};
 
-use pest::{Parser, iterators::Pair};
+use pest::{iterators::Pair, Parser};
 use pest_derive::Parser;
 
 use fs_err as fs;

--- a/tests/rustfmt-matching.rs
+++ b/tests/rustfmt-matching.rs
@@ -1,4 +1,4 @@
-use verusfmt::{VERUS_PREFIX, VERUS_SUFFIX, rustfmt};
+use verusfmt::{rustfmt, VERUS_PREFIX, VERUS_SUFFIX};
 
 /// Tests to check that when formatting standard Rust syntax,
 /// we match rustfmt


### PR DESCRIPTION
Reverts verus-lang/verusfmt#126 just until https://github.com/verus-lang/verus/pull/1385 is ready to make things a little easier