### PR TITLE
add support for opens_invariants set expr notation

### DIFF
--- a/src/verus.pest
+++ b/src/verus.pest
@@ -1823,6 +1823,7 @@ opens_invariants_mode = {
     any_str
   | none_str
   | lbracket_str ~ comma_delimited_exprs? ~ rbracket_str
+  | expr
 }
 
 opens_invariants_clause = {


### PR DESCRIPTION
This handles the support for specifying a vstd::Set<int> expression in the opens_invariants clause, which was added in https://github.com/verus-lang/verus/pull/1502