### PR TITLE
Braced syntax for `broadcast use`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Fix parser for patterns with `@` identifier binding
+* Add support for braced syntax for `broadcast use` (see [verus#1571](https://github.com/verus-lang/verus/pull/1571))
 
 # v0.5.5
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -891,7 +891,16 @@ fn to_doc<'a>(
         Rule::use_tree_list => comma_delimited(ctx, arena, pair, false).braces().group(),
         Rule::broadcast_use_list => {
             if pair.clone().into_inner().count() > 1 {
-                comma_delimited(ctx, arena, pair, false).braces().group()
+                // NOTE: Temporarily (see
+                // https://github.com/verus-lang/verus/pull/1571#issuecomment-2783727909) we are
+                // maintaining the deprecated non-braced syntax, if it is being used. At some point of
+                // time, we should update this which will migrate all code over.
+                let starts_with_curly = pair.as_str().trim_start().starts_with('{');
+                if starts_with_curly {
+                    comma_delimited(ctx, arena, pair, false).braces().group()
+                } else {
+                    comma_delimited(ctx, arena, pair, false).group()
+                }
             } else {
                 map_to_doc(ctx, arena, pair)
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -889,7 +889,13 @@ fn to_doc<'a>(
         Rule::r#use => map_to_doc(ctx, arena, pair),
         Rule::use_tree => map_to_doc(ctx, arena, pair),
         Rule::use_tree_list => comma_delimited(ctx, arena, pair, false).braces().group(),
-        Rule::broadcast_use_list => comma_delimited(ctx, arena, pair, false).group(),
+        Rule::broadcast_use_list => {
+            if pair.clone().into_inner().count() > 1 {
+                comma_delimited(ctx, arena, pair, false).braces().group()
+            } else {
+                map_to_doc(ctx, arena, pair)
+            }
+        }
         Rule::broadcast_group_member => map_to_doc(ctx, arena, pair),
         Rule::broadcast_group_list => comma_delimited(ctx, arena, pair, false).braces(),
         Rule::fn_qualifier => map_to_doc(ctx, arena, pair),

--- a/src/verus.pest
+++ b/src/verus.pest
@@ -993,7 +993,8 @@ meta = {
 }
 
 broadcast_use_list = {
-    (path ~ ("," ~ path)* ~ ","?)
+    ("{" ~ path ~ ("," ~ path)* ~ ","? ~ "}")
+  | (path ~ ("," ~ path)* ~ ","?)
 }
 
 broadcast_uses = {

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -2033,11 +2033,21 @@ broadcast use
 broadcast use super::raw_ptr::group_raw_ptr_axioms;
 broadcast use super::set_lib::group_set_lib_axioms;
 broadcast use super::set::group_set_axioms;
+broadcast use {
+    super::raw_ptr::group_raw_ptr_axioms,
+    super::set_lib::group_set_lib_axioms,
+    super::set::group_set_axioms};
+broadcast use {
+    super::raw_ptr::group_raw_ptr_axioms,
+    super::set_lib::group_set_lib_axioms,
+    super::set::group_set_axioms,};
+broadcast use {super::set::group_set_axioms};
+broadcast use {super::set::group_set_axioms,};
 }
 
 } // verus!
 "#;
-    assert_snapshot!(parse_and_format(file).unwrap(), @r###"
+    assert_snapshot!(parse_and_format(file).unwrap(), @r"
     verus! {
 
     mod ring {
@@ -2133,29 +2143,41 @@ broadcast use super::set::group_set_axioms;
         use builtin::*;
         use crate::ring::*;
 
-        broadcast use {Ring::spec_succ_ensures, Ring::spec_prev_ensures};
+        broadcast use Ring::spec_succ_ensures, Ring::spec_prev_ensures;
 
     }
 
     mod m5 {
-        broadcast use {
+        broadcast use
             super::raw_ptr::group_raw_ptr_axioms,
             super::set_lib::group_set_lib_axioms,
             super::set::group_set_axioms,
-        };
-        broadcast use {
+        ;
+        broadcast use
             super::raw_ptr::group_raw_ptr_axioms,
             super::set_lib::group_set_lib_axioms,
             super::set::group_set_axioms,
-        };
+        ;
         broadcast use super::raw_ptr::group_raw_ptr_axioms;
         broadcast use super::set_lib::group_set_lib_axioms;
+        broadcast use super::set::group_set_axioms;
+        broadcast use {
+            super::raw_ptr::group_raw_ptr_axioms,
+            super::set_lib::group_set_lib_axioms,
+            super::set::group_set_axioms,
+        };
+        broadcast use {
+            super::raw_ptr::group_raw_ptr_axioms,
+            super::set_lib::group_set_lib_axioms,
+            super::set::group_set_axioms,
+        };
+        broadcast use super::set::group_set_axioms;
         broadcast use super::set::group_set_axioms;
 
     }
 
     } // verus!
-    "###);
+    ");
 }
 
 #[test]

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -2019,6 +2019,22 @@ mod m4 {
                     Ring::spec_succ_ensures,
             Ring::spec_prev_ensures;
 }
+
+mod m5 {
+broadcast use
+    super::raw_ptr::group_raw_ptr_axioms,
+    super::set_lib::group_set_lib_axioms,
+    super::set::group_set_axioms,
+;
+broadcast use
+    super::raw_ptr::group_raw_ptr_axioms,
+    super::set_lib::group_set_lib_axioms,
+    super::set::group_set_axioms;
+broadcast use super::raw_ptr::group_raw_ptr_axioms;
+broadcast use super::set_lib::group_set_lib_axioms;
+broadcast use super::set::group_set_axioms;
+}
+
 } // verus!
 "#;
     assert_snapshot!(parse_and_format(file).unwrap(), @r###"
@@ -2117,7 +2133,24 @@ mod m4 {
         use builtin::*;
         use crate::ring::*;
 
-        broadcast use Ring::spec_succ_ensures, Ring::spec_prev_ensures;
+        broadcast use {Ring::spec_succ_ensures, Ring::spec_prev_ensures};
+
+    }
+
+    mod m5 {
+        broadcast use {
+            super::raw_ptr::group_raw_ptr_axioms,
+            super::set_lib::group_set_lib_axioms,
+            super::set::group_set_axioms,
+        };
+        broadcast use {
+            super::raw_ptr::group_raw_ptr_axioms,
+            super::set_lib::group_set_lib_axioms,
+            super::set::group_set_axioms,
+        };
+        broadcast use super::raw_ptr::group_raw_ptr_axioms;
+        broadcast use super::set_lib::group_set_lib_axioms;
+        broadcast use super::set::group_set_axioms;
 
     }
 


### PR DESCRIPTION
See https://github.com/verus-lang/verus/pull/1571.

This current PR maintains the non-braced `broadcast use` as non-braced; a future PR (once https://github.com/verus-lang/verus/pull/1571 has been merged for long enough) will switch to the braced style always.

Related: #86 and #130

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT](https://github.com/verus-lang/verusfmt/blob/main/LICENSE) license.</small>
