### PR TITLE
Add support for `default_ensures` syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Add support for the `default_ensures` syntax (see [verus#1551](https://github.com/verus-lang/verus/pull/1551))
+
 # v0.5.6
 
 * Fix parser for patterns with `@` identifier binding

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -767,6 +767,7 @@ fn to_doc<'a>(
             .nest(INDENT_SPACES),
 
         Rule::decreases_str
+        | Rule::default_ensures_str
         | Rule::ensures_str
         | Rule::returns_str
         | Rule::invariant_except_break_str
@@ -1382,6 +1383,7 @@ fn to_doc<'a>(
         Rule::verus_clause_non_expr => map_to_doc(ctx, arena, pair),
         Rule::requires_clause => map_to_doc(ctx, arena, pair),
         Rule::ensures_clause => map_to_doc(ctx, arena, pair),
+        Rule::default_ensures_clause => map_to_doc(ctx, arena, pair),
         Rule::returns_clause => map_to_doc(ctx, arena, pair),
         Rule::invariant_except_break_clause => map_to_doc(ctx, arena, pair),
         Rule::invariant_clause => map_to_doc(ctx, arena, pair),

--- a/src/verus.pest
+++ b/src/verus.pest
@@ -268,6 +268,7 @@ const_str = ${ "const" ~ !("_" | ASCII_ALPHANUMERIC) }
 continue_str = ${ "continue" ~ !("_" | ASCII_ALPHANUMERIC) }
 crate_str = ${ "crate" ~ !("_" | ASCII_ALPHANUMERIC) }
 decreases_str = ${ "decreases" ~ !("_" | ASCII_ALPHANUMERIC) }
+default_ensures_str = ${ "default_ensures" ~ !("_" | ASCII_ALPHANUMERIC) }
 default_str = ${ "default" ~ !("_" | ASCII_ALPHANUMERIC) }
 do_str = ${ "do" ~ !("_" | ASCII_ALPHANUMERIC) }
 dyn_str = ${ "dyn" ~ !("_" | ASCII_ALPHANUMERIC) }
@@ -724,7 +725,7 @@ use_tree_list = {
 }
 
 fn_qualifier = {
-    (requires_clause | recommends_clause | ensures_clause | returns_clause | decreases_clause | opens_invariants_clause | unwind_clause)*
+    (requires_clause | recommends_clause | ensures_clause | default_ensures_clause | returns_clause | decreases_clause | opens_invariants_clause | unwind_clause)*
 }
 
 fn_terminator = {
@@ -1790,6 +1791,7 @@ verus_clause_non_expr = _{
     "{"             // TODO: Why is this permitted here?
   | requires_str
   | ensures_str
+  | default_ensures_str
   | returns_str
   | invariant_except_break_str
   | invariant_str
@@ -1807,6 +1809,10 @@ requires_clause = {
 
 ensures_clause = {
     ensures_str ~ comma_delimited_exprs_for_verus_clauses?
+}
+
+default_ensures_clause = {
+    default_ensures_str ~ comma_delimited_exprs_for_verus_clauses?
 }
 
 returns_clause = {

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -3059,3 +3059,42 @@ verus!{ fn foo(e: E) -> u64 { match e { v@E::C1{x}=>x } } }
     } // verus!
     ")
 }
+
+#[test]
+fn verus_default_ensures() {
+    let file = r#"verus!{
+fn foo(i: u32) -> (r: u32) requires 0 <= i < 10 ensures i <= r default_ensures i == r { }
+fn bar(i: u32) -> (r: u32) default_ensures i == r requires 0 <= i < 10 ensures i <= r;
+fn baz(i: bool) default_ensures i {}
+}"#;
+    assert_snapshot!(parse_and_format(file).unwrap(), @r"
+    verus! {
+
+    fn foo(i: u32) -> (r: u32)
+        requires
+            0 <= i < 10,
+        ensures
+            i <= r,
+        default_ensures
+            i == r,
+    {
+    }
+
+    fn bar(i: u32) -> (r: u32)
+        default_ensures
+            i == r,
+        requires
+            0 <= i < 10,
+        ensures
+            i <= r,
+    ;
+
+    fn baz(i: bool)
+        default_ensures
+            i,
+    {
+    }
+
+    } // verus!
+    ")
+}


### PR DESCRIPTION
See https://github.com/verus-lang/verus/pull/1551


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT](https://github.com/verus-lang/verusfmt/blob/main/LICENSE) license.</small>
