### PR TITLE
Update parser to handle `@` identifier binding in patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix parser for patterns with `@` identifier binding
+
 # v0.5.5
 
 * Add support for the `axiom` syntax (see [verus#1518](https://github.com/verus-lang/verus/pull/1518))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1321,7 +1321,10 @@ fn to_doc<'a>(
         Rule::pat_no_top_alt => map_to_doc(ctx, arena, pair),
         Rule::pat_inner => map_to_doc(ctx, arena, pair),
         Rule::literal_pat => map_to_doc(ctx, arena, pair),
-        Rule::ident_pat => map_to_doc(ctx, arena, pair),
+        Rule::ident_pat => arena.concat(pair.into_inner().map(|p| match p.as_rule() {
+            Rule::at_str => arena.text(" @ "),
+            _ => to_doc(ctx, p, arena),
+        })),
         //Rule::wildcard_pat => arena.text("_"),
         Rule::end_only_range_pat => map_to_doc(ctx, arena, pair),
         Rule::ref_pat => arena.text("&").append(map_to_doc(ctx, arena, pair)),

--- a/src/verus.pest
+++ b/src/verus.pest
@@ -1716,7 +1716,7 @@ slice_pat = {
 }
 
 path_pat = {
-    path
+    !(name ~ at_str) ~ path
 }
 
 box_pat = {

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -2985,3 +2985,22 @@ proof fn foo(x: proof_fn(a: u32) -> u64, y: proof_fn[Send](a: u32) -> u64) {}
     } // verus!
     ")
 }
+
+#[test]
+fn at_patterns() {
+    // Regression test for https://github.com/verus-lang/verusfmt/issues/137
+    let file = r#"
+verus!{ fn foo(e: E) -> u64 { match e { v@E::C1{x}=>x } } }
+"#;
+    assert_snapshot!(parse_and_format(file).unwrap(), @r"
+    verus! {
+
+    fn foo(e: E) -> u64 {
+        match e {
+            v @ E::C1 { x } => x,
+        }
+    }
+
+    } // verus!
+    ")
+}


### PR DESCRIPTION
Fixes #137 


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT](https://github.com/verus-lang/verusfmt/blob/main/LICENSE) license.</small>
