### PR TITLE
Fix accidental attempted parse inside comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix accidental attempted `verus!` parse inside comments (fixes #146).
+
 # v0.5.7
 
 * Add support for the `default_ensures` syntax (see [verus#1551](https://github.com/verus-lang/verus/pull/1551))

--- a/examples/verus-snapshot/source/vstd/pervasive.rs
+++ b/examples/verus-snapshot/source/vstd/pervasive.rs
@@ -427,8 +427,8 @@ pub open spec fn cloned<T: Clone>(a: T, b: T) -> bool {
 }
 
 } // verus!
-
 verus! {
+
 /// The default behavior of the vstd library enforces writing panic-free code.
 /// While developers may still use panic, verification should ensure that any
 /// panic is provably unreachable.
@@ -440,8 +440,8 @@ pub open spec fn allow_panic() -> bool {
 #[doc(hidden)]
 #[verifier(external_body)]
 pub fn __call_panic(out: &[&str]) -> !
-requires
-    allow_panic()
+    requires
+        allow_panic(),
 {
     core::panic!("__call_panic {:?}", out);
 }
@@ -455,7 +455,6 @@ pub fn __new_argument<T: core::fmt::Debug>(v: &T) -> alloc::string::String {
 }
 
 } // verus!
-
 /// Replace panic macro with vpanic when needed.
 /// panic!{} may call panic_fmt with private rt::Argument, which could not
 /// be supported in verus.

--- a/src/verus-minimal.pest
+++ b/src/verus-minimal.pest
@@ -63,7 +63,7 @@ file = {
 
 /// Region of code that doesn't contain any Verus macro use whatsoever
 non_verus = @{
-  (!("verus" ~ WHITESPACE* ~ "!" ~ WHITESPACE* ~ "{") ~ (string | raw_string | byte_string | raw_byte_string | char | ANY))*
+  (!("verus" ~ WHITESPACE* ~ "!" ~ WHITESPACE* ~ "{") ~ (string | raw_string | byte_string | raw_byte_string | char | COMMENT | ANY))*
 }
 
 /// An actual use of the `verus! { ... }` macro

--- a/src/verus.pest
+++ b/src/verus.pest
@@ -88,7 +88,7 @@ file = {
 /// happens, then we need to make sure that we aren't accidentally starting
 /// parsing in the middle of the macro_rules macro body itself. Similarly, strings.
 non_verus = @{
-  (!("verus" ~ WHITESPACE* ~ "!" ~ WHITESPACE* ~ "{") ~ (macro_rules | string | raw_string | byte_string | raw_byte_string | ANY))*
+  (!("verus" ~ WHITESPACE* ~ "!" ~ WHITESPACE* ~ "{") ~ (macro_rules | string | raw_string | byte_string | raw_byte_string | COMMENT | ANY))*
 }
 
 /// An actual use of the `verus! { ... }` macro

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -3098,3 +3098,19 @@ fn baz(i: bool) default_ensures i {}
     } // verus!
     ")
 }
+
+#[test]
+fn verus_macro_inside_comment() {
+    // Regression test for https://github.com/verus-lang/verusfmt/issues/146
+    let file = r#"
+fn main() {}
+
+// verus!{
+"#;
+
+    assert_snapshot!(parse_and_format(file).unwrap(), @r"
+    fn main() {}
+
+    // verus!{
+    ");
+}


### PR DESCRIPTION
Fixes #146 

Interestingly, this surfaces a _tiny_ part of vstd that we were not parsing/formatting before, weirdly enough. Seems to essentially not impact anything else though, but I am surprised by the part of vstd it impacted.

At a high level, the `non_verus` rule exists to gobble up anything before a `verus! {`, and it does so one token at a time (unless it has a good reason to fast-forward; e.g., macros and strings; turns out comments are another good reason to fast-forward).  This does _not_ impact the way comments are handled elsewhere, this is purely a "before we see the `verus! {` thing.  Related reading (for why `non_verus` exists): f17e9f6fb6bc6b4c8aa244bce96efe1464b10621. See #72 for fixing this issue for strings.

<sup>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT](https://github.com/verus-lang/verusfmt/blob/main/LICENSE) license.</sup>
