### PR TITLE
Add support for upcoming change to Verus to support `assume_specification` for consts (verus-lang/verus#1825).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Fix accidental attempted `verus!` parse inside comments (fixes #146).
+* Add support for `assume_specification` for constants (see [verus#1825](https://github.com/verus-lang/verus/pull/1825))
 
 # v0.5.7
 

--- a/src/verus.pest
+++ b/src/verus.pest
@@ -748,7 +748,7 @@ assume_specification = {
     assume_specification_str ~
     generic_param_list? ~
     lbracket_str ~ assume_specification_for ~ rbracket_str ~
-    param_list ~
+    param_list? ~
     ret_type? ~
     where_clause? ~
     fn_qualifier ~

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -2735,9 +2735,18 @@ pub assume_specification<Key, Value, S>[HashMap::<Key, Value, S>::insert](
             }
         };
 
+assume_specification[char::REPLACEMENT_CHARACTER] -> (c: char)
+    ensures
+        c != '7',
+;
+
+assume_specification[C] -> u8
+    returns
+        7u8,
+;
 } // verus!
 "#;
-    assert_snapshot!(parse_and_format(file).unwrap(), @r"
+    assert_snapshot!(parse_and_format(file).unwrap(), @r###"
     verus! {
 
     pub assume_specification<T, const N: usize>[ <[T; N]>::as_slice ](ar: &[T; N]) -> (out: &[T])
@@ -2760,8 +2769,18 @@ pub assume_specification<Key, Value, S>[HashMap::<Key, Value, S>::insert](
             },
     ;
 
+    assume_specification[ char::REPLACEMENT_CHARACTER ] -> (c: char)
+        ensures
+            c != '7',
+    ;
+
+    assume_specification[ C ] -> u8
+        returns
+            7u8,
+    ;
+
     } // verus!
-    ")
+    "###)
 }
 
 #[test]


### PR DESCRIPTION

<sup>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT](https://github.com/verus-lang/verusfmt/blob/main/LICENSE) license.</sup>
