### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
-* Fix accidental attempted `verus!` parse inside comments (fixes #146).
+* Fix accidental attempted `verus!` parse inside comments (fixes [#146](https://github.com/verus-lang/verusfmt/issues/146))
+* Fix `no_unwind` parsing when `ensures` ends with a comma (fixes [#150](https://github.com/verus-lang/verusfmt/issues/150))
 * Add support for `assume_specification` for constants (see [verus#1825](https://github.com/verus-lang/verus/pull/1825))
 
 # v0.5.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# v0.6.0
+
 * Fix accidental attempted `verus!` parse inside comments (fixes [#146](https://github.com/verus-lang/verusfmt/issues/146))
 * Fix `no_unwind` parsing when `ensures` ends with a comma (fixes [#150](https://github.com/verus-lang/verusfmt/issues/150))
 * Add support for `assume_specification` for constants (see [verus#1825](https://github.com/verus-lang/verus/pull/1825))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1895,7 +1895,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "verusfmt"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "axoupdater",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verusfmt"
-version = "0.5.7"
+version = "0.6.0"
 edition = "2021"
 autoexamples = false
 license = "MIT"


### PR DESCRIPTION
Currently blocked on https://github.com/verus-lang/verus/pull/1904


<sup>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT](https://github.com/verus-lang/verusfmt/blob/main/LICENSE) license.</sup>
