### PR TITLE
Escape char support

### DIFF
--- a/src/verus.pest
+++ b/src/verus.pest
@@ -198,6 +198,7 @@ raw_byte_string = @{
 char = @{
     "'" ~ (
         ("\\u{" ~ ASCII_HEX_DIGIT+ ~ "}")
+      | ("\\x" ~ ('0'..'7') ~ ASCII_HEX_DIGIT) // match rustfmt, only accepts the range [\x00-\x7f]
       | ("\\" ~ ANY)
       | (!"'" ~ ANY)
     ) ~

--- a/tests/rustfmt-matching.rs
+++ b/tests/rustfmt-matching.rs
@@ -43,6 +43,10 @@ fn test() {
     let t = 'x';
     let t = '\\';
     let t = '\t';
+    let t = '\x0C';
+    let t = '\x41';
+    let t = '\x00';
+    let t = '\x7f';
     let t = '\u{00e9}';
 }
 "#;


### PR DESCRIPTION
Verus currently accepts the following code, which is unparsable by verusfmt:
```rust
use vstd::prelude::*;
verus! {

pub open spec fn char_match(c: char) -> bool {
    c == '\t' || c == '\x0C' || c == ' '
}

} // verus!
fn main() {}
```
We fail with the following error:
```
Error:
  × Failed to parse
   ╭─[verus-parse.rs:5:24]
 4 │ pub open spec fn char_match(c: char) -> bool {
 5 │     c == '\t' || c == '\x0C' || c == ' '
   ·                        ┬
   ·                        ╰── here
 6 │ }
   ╰────
  help: Expected one of: static_str
  ```
This PR adds support for escape characters (see the [wikipedia article](https://en.wikipedia.org/wiki/Escape_character#ASCII_escape_character) for additional background) 

<sup>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT](https://github.com/verus-lang/verusfmt/blob/main/LICENSE) license.</sup>
