### PR TITLE
Document verusfmt::skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ See `verusfmt --help` for more options and details.
     the comments in the reformatted code. Plus, firing up all of `rustc` just to
     format some code seems heavyweight.
 
+1. How to tell `verusfmt` to ignore something?
+
+    `#[verusfmt::skip]` 
+
 ## Future Work
 - Special handling for commonly used macros, like `println!`, `state_machine!`
 - Enforce the [Rust naming policy](https://doc.rust-lang.org/beta/style-guide/advice.html#names)? 


### PR DESCRIPTION
I didn't know about this until I happened to see it mentioned in a github issue


<sup>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT](https://github.com/verus-lang/verusfmt/blob/main/LICENSE) license.</sup>
