### PR TITLE
Document the verusfmt::skip attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ verusfmt foo.rs
 
 See `verusfmt --help` for more options and details.
 
+**Overriding verusfmt**
+
+To prevent `verusfmt` from processing a particular item or expression, add the `#[verusfmt::skip]` attribute.
+
 ## Goals
 
 1. Make it easier to read and contribute to [Verus] code by automatically


### PR DESCRIPTION
Add instructions for overriding verusfmt

<sup>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT](https://github.com/verus-lang/verusfmt/blob/main/LICENSE) license.</sup>
