### PR TITLE
Add support for `final` expressions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -790,6 +790,7 @@ fn to_doc<'a>(
         | Rule::exec_str
         | Rule::exists_str
         | Rule::false_str
+        | Rule::final_str
         | Rule::forall_str
         | Rule::none_str
         | Rule::proof_str
@@ -1402,6 +1403,7 @@ fn to_doc<'a>(
         | Rule::assert_by_prover_expr
         | Rule::assert_expr => map_to_doc(ctx, arena, pair).group(),
         Rule::assume_expr => map_to_doc(ctx, arena, pair),
+        Rule::final_expr => map_to_doc(ctx, arena, pair),
         Rule::assert_forall_expr => map_to_doc(ctx, arena, pair),
         Rule::prover => map_to_doc(ctx, arena, pair),
         Rule::inline_prover => map_to_doc(ctx, arena, pair).group(),

--- a/src/verus.pest
+++ b/src/verus.pest
@@ -289,6 +289,7 @@ FnMut_str = ${ "FnMut" ~ !("_" | ASCII_ALPHANUMERIC) }
 FnOnce_str = ${ "FnOnce" ~ !("_" | ASCII_ALPHANUMERIC) }
 FnSpec_str = ${ "FnSpec" ~ !("_" | ASCII_ALPHANUMERIC) }
 Fn_str = ${ "Fn" ~ !("_" | ASCII_ALPHANUMERIC) }
+final_str = ${ "final" ~ !("_" | ASCII_ALPHANUMERIC) }
 fn_str = ${ "fn" ~ !("_" | ASCII_ALPHANUMERIC) }
 forall_str = ${ "forall" ~ !("_" | ASCII_ALPHANUMERIC) }
 for_str = ${ "for" ~ !("_" | ASCII_ALPHANUMERIC) }
@@ -420,7 +421,7 @@ keyword = {
     | "become"
     | box_str
     | do_str
-    | "final"
+    | final_str
     | macro_str
     | "override"
     | "priv"
@@ -1099,6 +1100,7 @@ expr_inner_no_struct = _{
     array_expr
   | assert_expr
   | assume_expr
+  | final_expr
   | assert_forall_expr
   | bulleted_expr
   | bulleted_expr_inner
@@ -1882,6 +1884,10 @@ assert_expr = {
 
 assume_expr = {
     attr* ~ assume_str ~ lparen_str ~ expr ~ rparen_str
+}
+
+final_expr = {
+    final_str ~ lparen_str ~ expr ~ rparen_str
 }
 
 assert_forall_expr = {

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -3399,3 +3399,33 @@ pub fn test_raw_identifiers() {
     } // verus!
     "###);
 }
+
+#[test]
+fn verus_final_expr() {
+    let file = r#"
+verus! {
+
+pub fn vec_index_mut<T, A: Allocator>(vec: &mut Vec<T, A>, i: usize) -> (element: &mut T)
+    requires i < vec.view().len(),
+    ensures *element == old(vec)@.index(i as int), final(vec)@ == old(vec)@.update(i as int, *final(element)), *final(element) == final(vec).view().index(i as int),
+    no_unwind;
+
+}
+"#;
+
+    assert_snapshot!(parse_and_format(file).unwrap(), @r###"
+    verus! {
+
+    pub fn vec_index_mut<T, A: Allocator>(vec: &mut Vec<T, A>, i: usize) -> (element: &mut T)
+        requires
+            i < vec.view().len(),
+        ensures
+            *element == old(vec)@.index(i as int),
+            final(vec)@ == old(vec)@.update(i as int, *final(element)),
+            *final(element) == final(vec).view().index(i as int),
+        no_unwind
+    ;
+
+    } // verus!
+    "###);
+}


### PR DESCRIPTION
Adds support for `final` expressions.

Closes https://github.com/verus-lang/verusfmt/issues/175


<sup>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT](https://github.com/verus-lang/verusfmt/blob/main/LICENSE) license.</sup>
