### PR TITLE
feat: add support for specifying Rust edition in RustFmtConfig

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,8 +35,8 @@ struct Args {
     /// Use unstable CLI features
     #[arg(short = 'Z', long = "unstable")]
     unstable_command: Option<UnstableCommand>,
-    /// Rust edition to pass to rustfmt
-    #[arg(long, default_value = "2021")]
+    /// Rust edition for parts outside the Verus macro
+    #[arg(long, default_value = "2021", conflicts_with = "verus_only")]
     edition: String,
     /// Update verusfmt if an update is available
     #[arg(long = "update")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,9 @@ struct Args {
     /// Use unstable CLI features
     #[arg(short = 'Z', long = "unstable")]
     unstable_command: Option<UnstableCommand>,
+    /// Rust edition to pass to rustfmt
+    #[arg(long, default_value = "2021")]
+    edition: String,
     /// Update verusfmt if an update is available
     #[arg(long = "update")]
     update: bool,
@@ -60,7 +63,10 @@ fn format_file(file: &PathBuf, args: &Args) -> miette::Result<()> {
             .filter_map(|p| p.exists().then(|| fs::read_to_string(p).unwrap()))
             .next();
 
-        RustFmtConfig { rustfmt_toml }
+        RustFmtConfig {
+            rustfmt_toml,
+            edition: args.edition.clone(),
+        }
     };
 
     let formatted_output = verusfmt::run(

--- a/src/rustfmt.rs
+++ b/src/rustfmt.rs
@@ -31,11 +31,16 @@ pub struct RustFmtConfig {
     /// otherwise, uses the default behavior (i.e., picking up `rustfmt.toml` if it exists from
     /// the file's directory or ancestors)
     pub rustfmt_toml: Option<String>,
+    /// Rust edition to pass to rustfmt.
+    pub edition: String,
 }
 
 impl Default for RustFmtConfig {
     fn default() -> Self {
-        Self { rustfmt_toml: None }
+        Self {
+            rustfmt_toml: None,
+            edition: "2021".to_string(),
+        }
     }
 }
 
@@ -150,7 +155,9 @@ fn run_rustfmt(s: &str, config: &RustFmtConfig) -> Option<String> {
     let mut rustfmt = Command::new("rustfmt");
 
     // Set up standard arguments we always pass
-    rustfmt.arg("--emit=stdout").arg("--edition=2021");
+    rustfmt
+        .arg("--emit=stdout")
+        .arg(format!("--edition={}", config.edition));
 
     // If we need to, explicitly set up the rustfmt.toml file
     let tempdir = config.rustfmt_toml.as_ref().map(|toml| {

--- a/src/rustfmt.rs
+++ b/src/rustfmt.rs
@@ -31,7 +31,7 @@ pub struct RustFmtConfig {
     /// otherwise, uses the default behavior (i.e., picking up `rustfmt.toml` if it exists from
     /// the file's directory or ancestors)
     pub rustfmt_toml: Option<String>,
-    /// Rust edition to pass to rustfmt.
+    /// Rust edition for parts outside the Verus macro.
     pub edition: String,
 }
 

--- a/tests/snapshot-examples.rs
+++ b/tests/snapshot-examples.rs
@@ -97,6 +97,7 @@ fn verus_snapshot_unchanged(path: &std::path::Path) {
                     std::fs::read_to_string("./examples/verus-snapshot/source/rustfmt.toml")
                         .unwrap(),
                 ),
+                edition: "2021".to_string(),
             },
         },
     );


### PR DESCRIPTION
When format code
```rust
fn enqueue(&self, runnable: Arc<T>, flags: EnqueueFlags) -> Option<CpuId> {
    let mut rq = self.rq[target_cpu.as_usize()].disable_irq().lock();
    if still_in_rq && let Err(_) = runnable.cpu().set_if_is_none(target_cpu) {
        return None;
    }
    rq.queue.push_back(runnable);
    None
}
```
There will be error
```
rustfmt failed! error: let chains are only allowed in Rust 2024 or later
 --> <stdin>:3:23
  |
3 |     if still_in_rq && let Err(_) = runnable.cpu().set_if_is_none(target_cpu) {
  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


        Consider running with --verus-only

Error:   × rustfmt failed
```

which is caused by the hardcoded `edition`.

So, this PR make `edition` an argument and update the default `edition` to 2024.

<sup>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT](https://github.com/verus-lang/verusfmt/blob/main/LICENSE) license.</sup>
