### PR TITLE
fix: multiline block comment panic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,8 +314,10 @@ fn comment_to_doc<'a>(
 ) -> DocBuilder<'a, Arena<'a>> {
     assert!(matches!(pair.as_rule(), Rule::COMMENT));
     let (line, _col) = pair.line_col();
-    let s = arena.text(pair.as_str().trim());
-    if ctx.inline_comment_lines.contains(&line) {
+    let raw_comment = pair.as_str();
+    let is_single_line_comment = !raw_comment.contains('\n') && !raw_comment.contains('\r');
+    let s = arena.text(raw_comment.trim());
+    if is_single_line_comment && ctx.inline_comment_lines.contains(&line) {
         debug!(
             "contains(line = <<{}>>) = {}, with add_newline: {}",
             pair.as_str(),

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -17,6 +17,26 @@ fn parse_and_format(s: &str) -> miette::Result<String> {
 }
 
 #[test]
+fn inline_multiline_block_comment_with_line_comment_text() {
+    let file = r#"
+verus! { fn f() { x()/*//
+*/ } }
+"#;
+
+    assert_snapshot!(parse_and_format(file).unwrap(), @r###"
+    verus! {
+
+    fn f() {
+        x()/*//
+    */
+
+    }
+
+    } // verus!
+    "###);
+}
+
+#[test]
 fn verus_functions() {
     let file = r#"
 verus! {


### PR DESCRIPTION
When formatting code
```rust
verus! { fn f() { x()/*//
*/ } }
```
verusfmt will panic with
```
thread 'main' (1614637) panicked at src/lib.rs:1487:25:
Failed to find a comment!: */FORMATTER_FIXUP
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
in
https://github.com/verus-lang/verusfmt/blob/28b9abca07a332d15a7a1fa3c01b18e9d65681c4/src/lib.rs#L1487

This PR only applies inline-comment fixup markers to comments that are physically
single-line. Multiline block comments should use the existing multiline-comment path.

<sup>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT](https://github.com/verus-lang/verusfmt/blob/main/LICENSE) license.</sup>
