### PR TITLE
Fix parse errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1228,6 +1228,7 @@ fn to_doc<'a>(
             extra_spaced_braces(arena, comma_delimited(ctx, arena, pair, false)).group()
         }
         Rule::record_expr_field => map_to_doc(ctx, arena, pair),
+        Rule::record_field_key => map_to_doc(ctx, arena, pair),
         Rule::arg_list => sticky_delims(ctx, arena, pair, Enclosure::Parens, false),
         Rule::proof_fn_characteristics => {
             comma_delimited(ctx, arena, pair, false).group().brackets()
@@ -1370,6 +1371,7 @@ fn to_doc<'a>(
             spaced_braces(arena, comma_delimited(ctx, arena, pair, false)).group()
         }
         Rule::record_pat_field => map_to_doc(ctx, arena, pair),
+        Rule::record_pat_field_key => map_to_doc(ctx, arena, pair),
         Rule::tuple_struct_pat_inner => comma_delimited(ctx, arena, pair, false).parens().group(),
         Rule::tuple_struct_pat => map_to_doc(ctx, arena, pair),
         Rule::tuple_pat => comma_delimited(ctx, arena, pair, false).parens().group(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1398,6 +1398,9 @@ fn to_doc<'a>(
         Rule::single_expr_for_verus_clause => {
             comma_delimited_full(ctx, arena, pair).nest(INDENT_SPACES)
         }
+        Rule::single_returns_expr_for_verus_clause => {
+            comma_delimited_full(ctx, arena, pair).nest(INDENT_SPACES)
+        }
         Rule::verus_clause_non_expr => map_to_doc(ctx, arena, pair),
         Rule::requires_clause => map_to_doc(ctx, arena, pair),
         Rule::ensures_clause => map_to_doc(ctx, arena, pair),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -576,6 +576,26 @@ fn terminal_expr(pairs: &Pairs<Rule>) -> bool {
     e.is_some()
 }
 
+fn generic_param_with_empty_bound_to_doc<'a>(
+    ctx: &Context,
+    arena: &'a Arena<'a, ()>,
+    pair: Pair<'a, Rule>,
+) -> DocBuilder<'a, Arena<'a>> {
+    let has_empty_bound = pair
+        .clone()
+        .into_inner()
+        .any(|p| p.as_rule() == Rule::empty_type_bound_list);
+    if !has_empty_bound {
+        return map_to_doc(ctx, arena, pair);
+    }
+
+    arena.concat(pair.into_inner().filter_map(|p| match p.as_rule() {
+        Rule::colon_str | Rule::empty_type_bound_list => None,
+        Rule::COMMENT => Some(arena.space().append(arena.text(p.as_str().trim()))),
+        _ => Some(to_doc(ctx, p, arena)),
+    }))
+}
+
 fn debug_print(pair: Pair<Rule>, indent: usize) {
     if pair.as_rule() == Rule::COMMENT {
         print!(
@@ -1082,9 +1102,9 @@ fn to_doc<'a>(
         Rule::generic_param_list => comma_delimited(ctx, arena, pair, false).angles().group(),
         Rule::spaced_generic_param_list => map_to_doc(ctx, arena, pair).append(arena.space()),
         Rule::generic_param => map_to_doc(ctx, arena, pair),
-        Rule::type_param => map_to_doc(ctx, arena, pair),
+        Rule::type_param => generic_param_with_empty_bound_to_doc(ctx, arena, pair),
         Rule::const_param => map_to_doc(ctx, arena, pair),
-        Rule::lifetime_param => map_to_doc(ctx, arena, pair),
+        Rule::lifetime_param => generic_param_with_empty_bound_to_doc(ctx, arena, pair),
         Rule::where_clause => arena.space().append(map_to_doc(ctx, arena, pair)),
         Rule::where_preds => comma_delimited(ctx, arena, pair, false).group(),
         Rule::where_pred => map_to_doc(ctx, arena, pair),
@@ -1347,6 +1367,7 @@ fn to_doc<'a>(
         }
         Rule::dyn_trait_type => map_to_doc(ctx, arena, pair),
         Rule::type_bound_list => map_to_doc(ctx, arena, pair),
+        Rule::empty_type_bound_list => map_to_doc(ctx, arena, pair),
         Rule::type_bound => map_to_doc(ctx, arena, pair),
 
         //************************//

--- a/src/verus.pest
+++ b/src/verus.pest
@@ -566,8 +566,7 @@ macro_call = {
 // can switch to the alternative if we find situations where it might be better
 // suited.
 macro_call_stmt = {
-    calc_macro_call
-  | attr* ~ path ~ bang_str ~ !"=" ~ lbrace_str ~ token_tree* ~ rbrace_str
+    attr* ~ path ~ bang_str ~ !"=" ~ lbrace_str ~ token_tree* ~ rbrace_str
 }
 
 // See https://doc.rust-lang.org/beta/reference/tokens.html#punctuation
@@ -1050,11 +1049,12 @@ stmt = !{
   // We can't use `expr_with_block ~ semi_str?` here, and instead need to do it
   // as the two separate ordered alternatives (`ewb ~ semi_str | ewb`) to
   // prevent munching of multi-newlines that happens otherwise
-  | expr_with_block ~ semi_str
-  | expr_with_block
+  | !(block_expr ~ dot_str) ~ expr_with_block ~ semi_str
+  | !(block_expr ~ dot_str) ~ expr_with_block
   | expr ~ semi_str
   | item_no_macro_call
-  | macro_call_stmt
+  | calc_macro_call
+  | !(macro_call_stmt ~ dot_str) ~ macro_call_stmt
 }
 
 let_stmt = {

--- a/src/verus.pest
+++ b/src/verus.pest
@@ -1391,7 +1391,11 @@ record_expr_field_list = {
 }
 
 record_expr_field = {
-    attr* ~ (name ~ colon_str)? ~ expr
+    attr* ~ (record_field_key ~ colon_str)? ~ expr
+}
+
+record_field_key = {
+    name | int_number
 }
 
 arg_list = {
@@ -1702,7 +1706,11 @@ record_pat_field_list = {
 }
 
 record_pat_field = {
-    attr* ~ (name_ref ~ colon_str)? ~ pat
+    attr* ~ (record_pat_field_key ~ colon_str)? ~ pat
+}
+
+record_pat_field_key = {
+    name_ref | int_number
 }
 
 tuple_struct_pat_inner = {

--- a/src/verus.pest
+++ b/src/verus.pest
@@ -1795,6 +1795,10 @@ single_expr_for_verus_clause = {
     !verus_clause_non_expr ~ expr_no_struct ~ ","?
 }
 
+single_returns_expr_for_verus_clause = {
+    !verus_clause_non_expr ~ (struct_expr | expr_no_struct) ~ ","?
+}
+
 verus_clause_non_expr = _{
     "{"             // TODO: Why is this permitted here?
   | requires_str
@@ -1825,7 +1829,7 @@ default_ensures_clause = {
 }
 
 returns_clause = {
-    returns_str ~ single_expr_for_verus_clause
+    returns_str ~ single_returns_expr_for_verus_clause
 }
 
 invariant_except_break_clause = {

--- a/src/verus.pest
+++ b/src/verus.pest
@@ -950,7 +950,7 @@ generic_param = {
 }
 
 type_param = {
-    attr* ~ name ~ (colon_str ~ type_bound_list)? ~
+    attr* ~ name ~ (colon_str ~ (type_bound_list | empty_type_bound_list))? ~
     (eq_str ~ type)?
 }
 
@@ -960,7 +960,7 @@ const_param = {
 }
 
 lifetime_param = {
-    attr* ~ lifetime_no_space ~ (colon_str ~ type_bound_list)?
+    attr* ~ lifetime_no_space ~ (colon_str ~ (type_bound_list | empty_type_bound_list))?
 }
 
 where_clause = {
@@ -1628,6 +1628,10 @@ dyn_trait_type = {
 
 type_bound_list = {
     type_bound ~ (plus_str ~ type_bound)* ~ plus_str?
+}
+
+empty_type_bound_list = {
+    &("," | ">")
 }
 
 type_bound = {

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -553,6 +553,42 @@ verus!{
 }
 
 #[test]
+fn block_and_macro_expr_method_suffixes() {
+    let file = r#"
+verus! {
+fn block_suffix() {
+    {#[verus_spec(with => tracked_state)] acquire_lock()}.then(|| true)
+}
+
+fn macro_suffix() -> bool {
+    atomic_with_ghost! {
+        value
+    }.is_ok()
+}
+}
+"#;
+
+    assert_snapshot!(parse_and_format(file).unwrap(), @r###"
+    verus! {
+
+    fn block_suffix() {
+        {
+            #[verus_spec(with => tracked_state)]
+            acquire_lock()
+        }.then(|| true)
+    }
+
+    fn macro_suffix() -> bool {
+        atomic_with_ghost! {
+            value
+        }.is_ok()
+    }
+
+    } // verus!
+    "###);
+}
+
+#[test]
 fn verus_macro_statements() {
     let file = r#"
 verus! {

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -2900,6 +2900,13 @@ verus!{
         opens_invariants any
     {
     }
+
+    fn test5(self) -> DmaCoherent
+        returns
+            DmaCoherent { inner: self.inner },
+    {
+        self
+    }
 }
 "#;
     assert_snapshot!(parse_and_format(file).unwrap(), @r"
@@ -2945,6 +2952,13 @@ verus!{
             !b,
         opens_invariants any
     {
+    }
+
+    fn test5(self) -> DmaCoherent
+        returns
+            DmaCoherent { inner: self.inner },
+    {
+        self
     }
 
     } // verus!

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -1439,6 +1439,9 @@ struct RawVec<A: Allocator> {
 
 const impl<A: [const] Allocator> RawVec<A> {}
 
+impl<T: /* ?Sized*/ > MutexGuard<T> {
+}
+
 } // verus!
 "#;
 
@@ -1450,6 +1453,10 @@ const impl<A: [const] Allocator> RawVec<A> {}
     }
 
     const impl<A: [const] Allocator> RawVec<A> {
+
+    }
+
+    impl<T /* ?Sized*/> MutexGuard<T> {
 
     }
 

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -701,6 +701,15 @@ fn local_direct_update(loc1: Local, pq: int) -> bool {
     &&& loc2 == Local { heap: loc2.heap, ..loc1 }
 }
 
+pub struct PageTableEntry(pub usize);
+
+impl Clone for PageTableEntry {
+    fn clone(&self) -> Self {
+        let Self { 0: value } = self;
+        Self { 0: value }
+    }
+}
+
 } // verus!
 "#;
 
@@ -713,6 +722,15 @@ fn local_direct_update(loc1: Local, pq: int) -> bool {
 
     fn local_direct_update(loc1: Local, pq: int) -> bool {
         &&& loc2 == Local { heap: loc2.heap, ..loc1 }
+    }
+
+    pub struct PageTableEntry(pub usize);
+
+    impl Clone for PageTableEntry {
+        fn clone(&self) -> Self {
+            let Self { 0: value } = self;
+            Self { 0: value }
+        }
     }
 
     } // verus!


### PR DESCRIPTION
While formatting VOSTD code, we found several parse errors.

This PR fixes the following cases:

1. `returns` clause with a struct literal
2. numbered record fields
3. commented-out generic type bounds

## `returns_clause`
### PoC
```rust
verus! {
fn clone(self) -> DmaCoherent
    returns
        DmaCoherent { inner: self.inner },
{
    self
}
}
```

### Error Message
```
Error:   × Failed to parse
   ╭─[./out/returns_struct_literal_poc.rs:4:28]
 3 │     returns
 4 │         DmaCoherent { inner: self.inner },
   ·                            ┬
   ·                            ╰── here
 5 │ {
   ╰────
  help: Expected one of: COMMENT, at_str, bang_str, colons_str,
        dot_str, dot_dot_str, dot_dot_eq_str, lbracket_str,
        question_str, rarrow_str, semi_str, as_str, matches_str,
        generic_arg_list, has_or_nothas, is_or_notis, assignment_ops,
        bin_expr_ops_normal, record_expr_field_list, arg_list
```

## Record Field
### PoC
```rust
verus! {
pub struct PageTableEntry(pub usize);

impl Clone for PageTableEntry {
    fn clone(&self) -> Self {
        Self { 0: self.0 }
    }
}
}
```

### Error Message
```
Error:   × Failed to parse
   ╭─[./out/numbered_record_field_poc.rs:6:17]
 5 │     fn clone(&self) -> Self {
 6 │         Self { 0: self.0 }
   ·                 ┬
   ·                 ╰── here
 7 │     }
   ╰────
  help: Expected one of: COMMENT, at_str, dot_str, dot_dot_str,
        dot_dot_eq_str, lbracket_str, question_str, rarrow_str,
        as_str, matches_str, has_or_nothas, is_or_notis,
        bin_expr_ops_normal, struct_update_base, arg_list
```

## Commented-Out Generic Type Bound
### PoC
```rust
verus! {
impl<T: /* ?Sized*/ > MutexGuard<T> {
}
}
```

### Error Message
```
Error:   × Failed to parse
   ╭─[./out/commented_type_bound_poc.rs:2:21]
 1 │ verus! {
 2 │ impl<T: /* ?Sized*/ > MutexGuard<T> {
   ·                     ┬
   ·                     ╰── here
 3 │ }
   ╰────
  help: Expected one of: COMMENT, type_bound
```

### Formatted Code after Fixing
```rust
verus! {

impl<T /* ?Sized*/> MutexGuard<T> {

}

} // verus!
```

I refer to the behavior of rustfmt, which will format 
```rust
impl<T: /* ?Sized*/ > MutexGuard<T> {
}
```
into
```rust
impl<T /* ?Sized*/> MutexGuard<T> {}
```

<sup>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT](https://github.com/verus-lang/verusfmt/blob/main/LICENSE) license.</sup>
