### PR TITLE
Support labeled loops

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1280,7 +1280,7 @@ fn to_doc<'a>(
         Rule::loop_expr => loop_to_doc(ctx, arena, pair),
         Rule::for_expr => loop_to_doc(ctx, arena, pair),
         Rule::while_expr => loop_to_doc(ctx, arena, pair),
-        Rule::label => unsupported(pair),
+        Rule::label => map_to_doc(ctx, arena, pair),
         Rule::break_expr => maybe_space_to_doc(ctx, arena, pair),
         Rule::continue_expr => maybe_space_to_doc(ctx, arena, pair),
         Rule::match_expr => map_to_doc(ctx, arena, pair),

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -1544,7 +1544,7 @@ fn test() {
 }
 
 fn test() {
-    loop
+    'somelabel: loop
         invariant
             false,
         invariant_ensures
@@ -1587,7 +1587,7 @@ fn test() {
     }
 
     fn test() {
-        loop
+        'somelabel: loop
             invariant
                 false,
             invariant_ensures


### PR DESCRIPTION
Previously, verusfmt would refuse to format files that contained labeled loops. This change allows it to format these loops.

I don't know whether there is a good reason for the previous `unsupported(pair)` invocation. Simply mimicking the call to `loop_to_doc` as done for other loop constructs seems to work for my examples, though.
